### PR TITLE
disable yarn PnP, because it does not start with it.

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,1 @@
+nodeLinker: node-modules


### PR DESCRIPTION
I suspect dansup has this in a global/systemwide config file, because without disabling yarn PnP the project does not start (`yarn start`).

PnP is some special new way of installing packages that is not compatible with this project - see https://yarnpkg.com/features/pnp.

