### PR TITLE
Fix: unable to edit empty fields in "edit profile" and fix a few smaller things in "update website" page

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,1 @@
+nodeLinker: node-modules

--- a/src/app/(auth)/settings/profile.jsx
+++ b/src/app/(auth)/settings/profile.jsx
@@ -134,10 +134,16 @@ export default function Page() {
           borderBottomWidth={border ? 1 : 0}
           borderBottomColor="$gray4"
         >
-          <Link href={path}>
-            <Text fontSize="$6" flexWrap="wrap">
-              {value}
-            </Text>
+          <Link href={path} asChild>
+            <View
+              w="100%"
+              alignSelf="stretch"
+              pressStyle={{ backgroundColor: 'rgba(0,0,0,0.2)' }}
+            >
+              <Text fontSize="$6" flexWrap="wrap">
+                {value}
+              </Text>
+            </View>
           </Link>
         </View>
       ) : (

--- a/src/app/(auth)/settings/updateWebsite.jsx
+++ b/src/app/(auth)/settings/updateWebsite.jsx
@@ -35,7 +35,7 @@ export default function Page() {
     queryKey: ['profileById', userCache.id],
     queryFn: getAccountById,
   })
-  const [website, setWebsite] = useState(user.website.replace('https://', ''))
+  const [website, setWebsite] = useState(user.website?.replace('https://', ''))
   const [isSubmitting, setSubmitting] = useState(false)
 
   const mutation = useMutation({

--- a/src/app/(auth)/settings/updateWebsite.jsx
+++ b/src/app/(auth)/settings/updateWebsite.jsx
@@ -80,7 +80,7 @@ export default function Page() {
           <Text color="$gray8">Website</Text>
 
           <View alignItems="flex-end" justifyContent="flex-end">
-            <Text color="$gray9">{website?.length}/120</Text>
+            <Text color="$gray9">{website?.length||0}/120</Text>
           </View>
         </XStack>
         <Input
@@ -90,7 +90,7 @@ export default function Page() {
           borderTopWidth={0}
           bg="white"
           maxLength={120}
-          placeholder="Add your full name, or nickname"
+          placeholder="example.com"
           p="0"
           m="0"
           size="$6"


### PR DESCRIPTION
Make full value clickable in `<LinkField>`
    
I attempted to restore the press style by using pressStyle. I have no idea how to test whether this affects accessibility tools, but now fields without content are clickable.

Ideally we would instead show an edit button at the end of the line, then it would also be more clear that you can not edit the username.

Also found out that clicking on the empty website field leads to a crash/error and fixed that.

- this pr includes #162, because without it the project doesn't work on my machine.
- closes #152
- fix bug that prevented website edit page from opening when no website was set before
  - This is a classical example of an error that would have been catched by strict typescript (strictNullChecks=true, noImplicitAny=true)
- fix placeholder in website edit page and default to "0/120" for the char count instead of "/120"