### PR TITLE
[Bugfix] move duplicated like functionality into new `useLikeMutation` hook and add it to 2 pages where it was missing

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,1 @@
+nodeLinker: node-modules

--- a/src/app/(auth)/(tabs)/index.tsx
+++ b/src/app/(auth)/(tabs)/index.tsx
@@ -13,8 +13,6 @@ import {
 } from '@tanstack/react-query'
 import {
   fetchHomeFeed,
-  likeStatus,
-  unlikeStatus,
   deleteStatusV1,
   postBookmark,
   getSelfAccount,
@@ -29,6 +27,7 @@ import CommentFeed from 'src/components/post/CommentFeed'
 import { useShareIntentContext } from 'expo-share-intent'
 import { useVideo } from 'src/hooks/useVideoProvider'
 import { useFocusEffect } from '@react-navigation/native'
+import { useLikeMutation } from 'src/hooks/mutations/useLikeMutation'
 
 export function ErrorBoundary(props: ErrorBoundaryProps) {
   return (
@@ -57,6 +56,8 @@ export default function HomeScreen() {
   const { hasShareIntent } = useShareIntentContext()
   const params = useLocalSearchParams()
   const [isPosting, setIsPosting] = useState(false)
+
+  const { handleLike } = useLikeMutation()
 
   useEffect(() => {
     if (hasShareIntent) {
@@ -204,30 +205,6 @@ export default function HomeScreen() {
       console.error('Error handled by share useMutation:', error)
     },
   })
-
-  const likeMutation = useMutation({
-    mutationFn: async (handleLike) => {
-      try {
-        return handleLike.type === 'like'
-          ? await likeStatus(handleLike)
-          : await unlikeStatus(handleLike)
-      } catch (error) {
-        console.error('Error within mutationFn:', error)
-        throw error
-      }
-    },
-    onError: (error) => {
-      console.error('Error handled by like useMutation:', error)
-    },
-  })
-
-  const handleLike = async (id, state) => {
-    try {
-      likeMutation.mutate({ type: state ? 'unlike' : 'like', id: id })
-    } catch (error) {
-      console.error('Error occurred during share:', error)
-    }
-  }
 
   const handleShowLikes = (id) => {
     bottomSheetModalRef.current?.close()

--- a/src/app/(auth)/(tabs)/network.tsx
+++ b/src/app/(auth)/(tabs)/network.tsx
@@ -28,6 +28,7 @@ import { BottomSheetModal, BottomSheetBackdrop } from '@gorhom/bottom-sheet'
 import CommentFeed from 'src/components/post/CommentFeed'
 import { useVideo } from 'src/hooks/useVideoProvider'
 import { useFocusEffect } from '@react-navigation/native'
+import { useLikeMutation } from 'src/hooks/mutations/useLikeMutation'
 
 export function ErrorBoundary(props: ErrorBoundaryProps) {
   return (
@@ -183,29 +184,7 @@ export default function HomeScreen() {
     },
   })
 
-  const likeMutation = useMutation({
-    mutationFn: async (handleLike) => {
-      try {
-        return handleLike.type === 'like'
-          ? await likeStatus(handleLike)
-          : await unlikeStatus(handleLike)
-      } catch (error) {
-        console.error('Error within mutationFn:', error)
-        throw error
-      }
-    },
-    onError: (error) => {
-      console.error('Error handled by like useMutation:', error)
-    },
-  })
-
-  const handleLike = async (id, state) => {
-    try {
-      likeMutation.mutate({ type: state ? 'unlike' : 'like', id: id })
-    } catch (error) {
-      console.error('Error occurred during share:', error)
-    }
-  }
+  const { handleLike } = useLikeMutation()
 
   const handleShowLikes = (id) => {
     bottomSheetModalRef.current?.close()

--- a/src/app/(auth)/post/[id].js
+++ b/src/app/(auth)/post/[id].js
@@ -1,3 +1,4 @@
+//@ts-check
 import { FlatList, Dimensions, ActivityIndicator, Platform } from 'react-native'
 import { Image, ScrollView, Text, View, YStack } from 'tamagui'
 import ProfileHeader from '@components/profile/ProfileHeader'
@@ -10,8 +11,6 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import {
   getStatusById,
   getAccountStatusesById,
-  likeStatus,
-  unlikeStatus,
   deleteStatusV1,
   reblogStatus,
   unreblogStatus,
@@ -23,6 +22,8 @@ import {
   BottomSheetBackdrop,
 } from '@gorhom/bottom-sheet'
 import CommentFeed from 'src/components/post/CommentFeed'
+import { useLikeMutation } from 'src/hooks/mutations/useLikeMutation'
+
 
 export default function Page() {
   const { id } = useLocalSearchParams()
@@ -54,12 +55,7 @@ export default function Page() {
     bottomSheetModalRef.current?.present()
   }, [])
 
-  const likeMutation = useMutation({
-    mutationFn: async (handleLike) => {
-      return handleLike.type === 'like'
-        ? await likeStatus(handleLike)
-        : await unlikeStatus(handleLike)
-    },
+  const { handleLike } = useLikeMutation({
     onSuccess: () => {
       setTimeout(() => {
         queryClient.invalidateQueries({ queryKey: ['getStatusById'] })
@@ -78,10 +74,6 @@ export default function Page() {
         : await unreblogStatus(handleShare)
     },
   })
-
-  const handleLike = async (id, state) => {
-    likeMutation.mutate({ type: state ? 'unlike' : 'like', id: id })
-  }
 
   const handleGotoUsernameProfile = (id) => {
     bottomSheetModalRef.current?.close()

--- a/src/app/(auth)/profile/bookmarks/index.jsx
+++ b/src/app/(auth)/profile/bookmarks/index.jsx
@@ -1,3 +1,4 @@
+//@ts-check
 import { Stack, useNavigation, useRouter } from 'expo-router'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { Text, View } from 'tamagui'
@@ -7,6 +8,7 @@ import { useInfiniteQuery, useMutation, useQueryClient } from '@tanstack/react-q
 import FeedPost from 'src/components/post/FeedPost'
 import { useCallback, useLayoutEffect } from 'react'
 import { Storage } from 'src/state/cache'
+import { useLikeMutation } from 'src/hooks/mutations/useLikeMutation'
 
 export default function LikesScreen() {
   const router = useRouter()
@@ -14,6 +16,7 @@ export default function LikesScreen() {
   useLayoutEffect(() => {
     navigation.setOptions({ title: 'My Bookmarks', headerBackTitle: 'Back' })
   }, [navigation])
+  const { handleLike } = useLikeMutation()
   const userJson = Storage.getString('user.profile')
   const user = JSON.parse(userJson)
   const renderItem = useCallback(

--- a/src/app/(auth)/profile/likes/index.jsx
+++ b/src/app/(auth)/profile/likes/index.jsx
@@ -7,6 +7,7 @@ import { useInfiniteQuery, useMutation, useQueryClient } from '@tanstack/react-q
 import FeedPost from 'src/components/post/FeedPost'
 import { useCallback, useLayoutEffect } from 'react'
 import { Storage } from 'src/state/cache'
+import { useLikeMutation } from 'src/hooks/mutations/useLikeMutation'
 
 export default function LikesScreen() {
   const router = useRouter()
@@ -14,6 +15,7 @@ export default function LikesScreen() {
   useLayoutEffect(() => {
     navigation.setOptions({ title: 'My Likes', headerBackTitle: 'Back' })
   }, [navigation])
+  const { handleLike } = useLikeMutation()
   const userJson = Storage.getString('user.profile')
   const user = JSON.parse(userJson)
   const renderItem = useCallback(

--- a/src/hooks/mutations/useLikeMutation.ts
+++ b/src/hooks/mutations/useLikeMutation.ts
@@ -1,0 +1,33 @@
+import { useMutation } from "@tanstack/react-query";
+import { likeStatus, unlikeStatus } from "src/lib/api";
+
+type onSucessType = Parameters<typeof useMutation>[0]['onSuccess']
+
+export function useLikeMutation({onSuccess}:{onSuccess?: onSucessType}={}) {
+  const likeMutation = useMutation({
+    mutationFn: async (handleLike) => {
+      try {
+        return handleLike.type === "like"
+          ? await likeStatus(handleLike)
+          : await unlikeStatus(handleLike);
+      } catch (error) {
+        console.error("Error within mutationFn:", error);
+        throw error; // the thrown error is not handled? the count is still updated / not reverted in ui
+      }
+    },
+    onError: (error) => {
+      console.error("Error handled by like useMutation:", error);
+    },
+    onSuccess
+  });
+
+  const handleLike = async (id: string, state: boolean) => {    
+    try {
+      likeMutation.mutate({ type: state ? "unlike" : "like", id: id });
+    } catch (error) {
+      console.error("Error occurred during like:", error);
+    }
+  };
+
+  return { handleLike };
+}


### PR DESCRIPTION
- **disable yarn PnP, because it does not start with it.**
- **move duplicated like functionality into new `useLikeMutation` hook and add it to 2 pages where it was missing.**

fixes https://github.com/pixelfed/pixelfed-rn/issues/137