### PR TITLE
Invalidate self posts on new post

### DIFF
--- a/src/app/(auth)/(tabs)/camera.tsx
+++ b/src/app/(auth)/(tabs)/camera.tsx
@@ -35,7 +35,7 @@ import {
   SCREEN_WIDTH,
 } from '@gorhom/bottom-sheet'
 import { Switch } from 'src/components/form/Switch'
-import { useQuery } from '@tanstack/react-query'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 import {
   getInstanceV1,
   getComposeSettings,
@@ -65,6 +65,7 @@ export default function Camera() {
   const [curAltext, setCurAltext] = useState('')
   const [canPost, setCanPost] = useState(false)
   const [isPosting, setIsPosting] = useState(false)
+  const queryClient = useQueryClient()
   const scopeLabel = {
     public: 'Anyone can view',
     unlisted: 'Unlisted from feeds',
@@ -402,6 +403,7 @@ export default function Camera() {
       .then((res) => {
         resetForm()
         router.replace('/?ref30=1')
+        queryClient.invalidateQueries({ queryKey: ['statusesById', userSelf?.id] })}
       })
   }
 


### PR DESCRIPTION
Addresses https://github.com/pixelfed/pixelfed-rn/issues/102

### Issue

When you upload a new post and navigate to your profile, your profile does not update. (Occurred on my Android Phone)

### Reproduction steps
1. Go to camera view, update new post.
2. Wait for update to complete, verify you can see your post on index
3. Navigate to your profile, using the bottom nav bar
4. Confirm latest post is not listed on your profile

### Worth noting

Does not appear to happen when you go to your profile using the profile link on top of the new post on your feed. I didn't look into it tbf.

### What this change does

This change invalidates self user's statuses query cache on successful post upload
