### PR TITLE
Downgrade vision-camera to fix Android builds

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,7 @@
         "react-native-static-safe-area-insets": "^2.2.0",
         "react-native-svg": "^15.4.0",
         "react-native-video": "^6.2.0",
-        "react-native-vision-camera": "^4.6.3",
+        "react-native-vision-camera": "4.6.1",
         "react-native-web": "~0.19.6",
         "semver": ">=7.5.2",
         "tamagui": "^1.94.4",
@@ -17536,9 +17536,10 @@
       }
     },
     "node_modules/react-native-vision-camera": {
-      "version": "4.6.3",
-      "resolved": "https://registry.npmjs.org/react-native-vision-camera/-/react-native-vision-camera-4.6.3.tgz",
-      "integrity": "sha512-fVHww4cNFrxvMYOlUZcjl3iYmR3vcUtvLZKW9NHlKZ3o4zsspwYjbw2vheZvHrHtJ30OrE3N2NFqT6CxgPvRCw==",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/react-native-vision-camera/-/react-native-vision-camera-4.6.1.tgz",
+      "integrity": "sha512-USp7g+Q/H7nzIS2XBJTWVdzZArxgZu+IFafgswVzxdmr0iSpLjLUtoUp+SUWxZ+nLhJriYYvqg8hfZrJtnpnlw==",
+      "license": "MIT",
       "peerDependencies": {
         "@shopify/react-native-skia": "*",
         "react": "*",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "react-native-static-safe-area-insets": "^2.2.0",
     "react-native-svg": "^15.4.0",
     "react-native-video": "^6.2.0",
-    "react-native-vision-camera": "^4.6.3",
+    "react-native-vision-camera": "4.6.1",
     "react-native-web": "~0.19.6",
     "semver": ">=7.5.2",
     "tamagui": "^1.94.4",


### PR DESCRIPTION
`react-native-vision-camera@4.6.2`  updated the Kotlin coroutines dependency to `1.9.0`, which is built using Kotlin `2.1.0`.

Expo is incompatible with Kotlin `2.1.0`, so we have to freeze `react-native-vision-camera` at `4.6.1` until expo bumps their Kotlin version.

Closes #179 