### PR TITLE
Fix password managers breaking authentication flow

### DIFF
--- a/src/state/AuthProvider.tsx
+++ b/src/state/AuthProvider.tsx
@@ -136,7 +136,8 @@ export default function AuthProvider({ children }: { children: ReactNode }) {
         `&scope=read+write+follow+push+admin:read+admin:write` +
         `&redirect_uri=${REDIRECT_URI}` +
         `&response_type=code`,
-      REDIRECT_URI
+      REDIRECT_URI,
+      { showInRecents: true }
     ).then((res) => {
       if (res.type === 'success') {
         return _loginCallback(res.url)

--- a/src/state/AuthProvider.tsx
+++ b/src/state/AuthProvider.tsx
@@ -78,7 +78,7 @@ export const AuthContext = createContext<AuthProvider>({
 
 export function useAuth() {
   if (!useContext(AuthContext)) {
-    // This does not work, because default is an object which js will inteprete as true here
+    // This does not work, because default is an object which js will interpret as true here
     throw new Error('useAuth must be used within a <AuthProvider />')
   }
 


### PR DESCRIPTION
Switching away from Pixelfed closes the in-app web browser and breaks the login flow. This can happen when a user opens their password manager to unlock it or has 2FA enabled on their Mastodon instance, uses "Sign in with Mastodon" and switches away to their 2FA app of choice.

The workaround here is described in an expo issue: https://github.com/expo/expo/issues/15276. Nothing changes from the user's point of view. The issue will probably be fixed in the next expo release, in this PR: https://github.com/expo/expo/pull/34160, but it will probably take us quite some time, before we're at a point when we can upgrade safely.

Closes #184 