### PR TITLE
Double Tap to Like

### DIFF
--- a/src/app/(auth)/(tabs)/index.tsx
+++ b/src/app/(auth)/(tabs)/index.tsx
@@ -32,7 +32,6 @@ import CommentFeed from 'src/components/post/CommentFeed'
 import { useShareIntentContext } from 'expo-share-intent'
 import { useVideo } from 'src/hooks/useVideoProvider'
 import { useFocusEffect } from '@react-navigation/native'
-import { useLikeMutation } from 'src/hooks/mutations/useLikeMutation'
 import { useUserCache } from 'src/state/AuthProvider'
 
 export function ErrorBoundary(props: ErrorBoundaryProps) {
@@ -62,8 +61,6 @@ export default function HomeScreen() {
   const { hasShareIntent } = useShareIntentContext()
   const params = useLocalSearchParams()
   const [isPosting, setIsPosting] = useState(false)
-
-  const { handleLike } = useLikeMutation()
 
   useEffect(() => {
     if (hasShareIntent) {
@@ -144,7 +141,6 @@ export default function HomeScreen() {
         post={item}
         user={user}
         onOpenComments={() => onOpenComments(item.id)}
-        onLike={() => handleLike(item.id, item.favourited)}
         onDeletePost={() => onDeletePost(item.id)}
         onBookmark={() => onBookmark(item.id)}
         onShare={() => onShare(item.id, item.reblogged)}

--- a/src/app/(auth)/(tabs)/network.tsx
+++ b/src/app/(auth)/(tabs)/network.tsx
@@ -31,7 +31,6 @@ import { BottomSheetModal, BottomSheetBackdrop } from '@gorhom/bottom-sheet'
 import CommentFeed from 'src/components/post/CommentFeed'
 import { useVideo } from 'src/hooks/useVideoProvider'
 import { useFocusEffect } from '@react-navigation/native'
-import { useLikeMutation } from 'src/hooks/mutations/useLikeMutation'
 import { useUserCache } from 'src/state/AuthProvider'
 import type { Status } from 'src/lib/api-types'
 
@@ -121,7 +120,6 @@ export default function HomeScreen() {
         post={item}
         user={user}
         onOpenComments={() => onOpenComments(item.id)}
-        onLike={() => handleLike(item.id, item.favourited)}
         onDeletePost={() => onDeletePost(item.id)}
         onBookmark={() => onBookmark(item.id)}
         onShare={() => onShare(item.id, item.reblogged)}
@@ -187,8 +185,6 @@ export default function HomeScreen() {
       console.error('Error handled by share useMutation:', error)
     },
   })
-
-  const { handleLike } = useLikeMutation()
 
   const handleShowLikes = (id: string) => {
     bottomSheetModalRef.current?.close()

--- a/src/app/(auth)/post/[id].tsx
+++ b/src/app/(auth)/post/[id].tsx
@@ -9,7 +9,6 @@ import { getStatusById, deleteStatusV1, reblogStatus, unreblogStatus } from 'src
 import FeedPost from 'src/components/post/FeedPost'
 import { BottomSheetModal, BottomSheetBackdrop } from '@gorhom/bottom-sheet'
 import CommentFeed from 'src/components/post/CommentFeed'
-import { useLikeMutation } from 'src/hooks/mutations/useLikeMutation'
 import { useUserCache } from 'src/state/AuthProvider'
 
 export default function Page() {
@@ -41,14 +40,6 @@ export default function Page() {
   const onOpenComments = useCallback((id: string) => {
     bottomSheetModalRef.current?.present()
   }, [])
-
-  const { handleLike } = useLikeMutation({
-    onSuccess: () => {
-      setTimeout(() => {
-        queryClient.invalidateQueries({ queryKey: ['getStatusById'] })
-      }, 1000)
-    },
-  })
 
   const onShare = (id: string, state) => {
     shareMutation.mutate({ type: state == true ? 'unreblog' : 'reblog', id: id })
@@ -137,7 +128,6 @@ export default function Page() {
           post={data}
           user={user}
           onOpenComments={onOpenComments}
-          onLike={handleLike}
           onDeletePost={onDeletePost}
           disableReadMore={true}
           isPermalink={true}

--- a/src/app/(auth)/profile/bookmarks/index.tsx
+++ b/src/app/(auth)/profile/bookmarks/index.tsx
@@ -7,7 +7,6 @@ import { ActivityIndicator, FlatList } from 'react-native'
 import { useInfiniteQuery } from '@tanstack/react-query'
 import FeedPost from 'src/components/post/FeedPost'
 import { useCallback, useLayoutEffect } from 'react'
-import { useLikeMutation } from 'src/hooks/mutations/useLikeMutation'
 import { useUserCache } from 'src/state/AuthProvider'
 
 export default function LikesScreen() {
@@ -15,7 +14,6 @@ export default function LikesScreen() {
   useLayoutEffect(() => {
     navigation.setOptions({ title: 'My Bookmarks', headerBackTitle: 'Back' })
   }, [navigation])
-  const { handleLike } = useLikeMutation()
   const user = useUserCache()
   const renderItem = useCallback(
     ({ item }) => (
@@ -23,7 +21,6 @@ export default function LikesScreen() {
         post={item}
         user={user}
         onOpenComments={() => onOpenComments(item.id)}
-        onLike={() => handleLike(item.id, item.favourited)}
         onDeletePost={() => onDeletePost(item.id)}
         onBookmark={() => onBookmark(item.id)}
       />

--- a/src/app/(auth)/profile/likes/index.tsx
+++ b/src/app/(auth)/profile/likes/index.tsx
@@ -6,15 +6,15 @@ import { ActivityIndicator, FlatList } from 'react-native'
 import { useInfiniteQuery } from '@tanstack/react-query'
 import FeedPost from 'src/components/post/FeedPost'
 import { useCallback, useLayoutEffect } from 'react'
-import { useLikeMutation } from 'src/hooks/mutations/useLikeMutation'
 import { useUserCache } from 'src/state/AuthProvider'
 
 export default function LikesScreen() {
   const navigation = useNavigation()
+
   useLayoutEffect(() => {
     navigation.setOptions({ title: 'My Likes', headerBackTitle: 'Back' })
   }, [navigation])
-  const { handleLike } = useLikeMutation()
+  
   const user = useUserCache()
   const renderItem = useCallback(
     ({ item }) => (
@@ -22,7 +22,6 @@ export default function LikesScreen() {
         post={item}
         user={user}
         onOpenComments={() => onOpenComments(item.id)}
-        onLike={() => handleLike(item.id, item.favourited)}
         onDeletePost={() => onDeletePost(item.id)}
         onBookmark={() => onBookmark(item.id)}
         isLikeFeed={true}

--- a/src/components/common/LikeButton.tsx
+++ b/src/components/common/LikeButton.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import Animated, {
   useSharedValue,
   withSpring,
@@ -16,13 +16,17 @@ type LikeButtonProps = {
 }
 
 export default function LikeButton(props: LikeButtonProps) {
-  const liked = useSharedValue(props.hasLiked ? 1 : 0)
+  const likeAnimation = useSharedValue(props.hasLiked ? 1 : 0);
+
+  useEffect(() => {
+    likeAnimation.value = withSpring<number>(props.hasLiked ? 1 : 0);
+  }, [props.hasLiked])
 
   const outlineStyle = useAnimatedStyle(() => {
     return {
       transform: [
         {
-          scale: interpolate(liked.value, [0, 1], [1, 0], Extrapolate.CLAMP),
+          scale: interpolate(likeAnimation.value, [0, 1], [1, 0], Extrapolate.CLAMP),
         },
       ],
     }
@@ -32,16 +36,15 @@ export default function LikeButton(props: LikeButtonProps) {
     return {
       transform: [
         {
-          scale: liked.value,
+          scale: likeAnimation.value,
         },
       ],
-      opacity: liked.value,
+      opacity: likeAnimation.value,
     }
   })
 
   const handleLike = () => {
     Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium)
-    liked.value = withSpring(liked.value ? 0 : 1)
     props.handleLike()
   }
 

--- a/src/components/post/FeedPost.tsx
+++ b/src/components/post/FeedPost.tsx
@@ -683,11 +683,18 @@ export default function FeedPost({
     handleLike(post?.id, currentHasLiked);
   }
 
+  const handleDoubleTap = () => {
+    // only allow liking with double tap, not unliking
+    if (!hasLiked) {
+      handleLikeAction();
+    }
+  }
+
   const doubleTap = Gesture.Tap()
   .maxDuration(250)
   .numberOfTaps(2)
   .onStart(() => {
-    runOnJS(handleLikeAction)();
+    runOnJS(handleDoubleTap)();
   });
 
   const _onDeletePost = (id: string) => {

--- a/src/hooks/mutations/useLikeMutation.ts
+++ b/src/hooks/mutations/useLikeMutation.ts
@@ -21,9 +21,16 @@ export function useLikeMutation({ onSuccess }: { onSuccess?: onSucessType } = {}
     onSuccess,
   })
 
-  const handleLike = async (id: string, state: boolean | undefined) => {
+  /**
+   * handler function for 'like' mutations that occur when a post is 
+   * liked or unliked
+   * 
+   * @param id string id of the post that has been liked/unliked
+   * @param liked value of the posts like status, true = 'like', false = 'unlike'
+   */
+  const handleLike = async (id: string, liked: boolean) => {
     try {
-      likeMutation.mutate({ type: state ? 'unlike' : 'like', id: id })
+      likeMutation.mutate({ type: liked ? 'like' : 'unlike', id: id })
     } catch (error) {
       console.error('Error occurred during like:', error)
     }


### PR DESCRIPTION
Addresses Issue #15 
Implements double tapping to like posts (but not unlike).

Changes:
 - Added double tap detection.
 - Adjusted animation triggering in `<LikeButton>` to trigger on `hasLiked` value change rather than `onPress` to work with double taps.
 - Moved `hasLiked` and `likeCount` states out of `<PostActions>` so they could be used by new `handleLikeAction` function (called by both like button and double tap).
 - Removed weird state "caching" (not really caching just using states badly) in `handleLikeCached`, instead handling undefined values with `??` operator inside the `useState` default values.
 - Refactor `useLikeMutation` into `<FeedPost>` (the only place that uses it).
 - Renamed `state` to `liked` in `useLikeMutation` and added jsdoc comment to improve readability and made `true = 'liked'` and `false = 'unliked'` to avoid unintuitive usage.
 
 Passes all manual tests (on IOS), but no unit tests.