### PR TITLE
Feature/i18n

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -22,7 +22,7 @@
     <meta-data android:name="expo.modules.updates.EXPO_SDK_VERSION" android:value="50.0.0"/>
     <meta-data android:name="expo.modules.updates.EXPO_UPDATES_CHECK_ON_LAUNCH" android:value="ALWAYS"/>
     <meta-data android:name="expo.modules.updates.EXPO_UPDATES_LAUNCH_WAIT_MS" android:value="0"/>
-    <activity android:name=".MainActivity" android:configChanges="keyboard|keyboardHidden|orientation|screenSize|screenLayout|uiMode" android:launchMode="singleTask" android:windowSoftInputMode="adjustResize" android:theme="@style/Theme.App.SplashScreen" android:exported="true" android:screenOrientation="portrait">
+    <activity android:name=".MainActivity" android:configChanges="keyboard|keyboardHidden|orientation|screenSize|screenLayout|uiMode|locale|layoutDirection" android:launchMode="singleTask" android:windowSoftInputMode="adjustResize" android:theme="@style/Theme.App.SplashScreen" android:exported="true" android:screenOrientation="portrait">
       <intent-filter>
         <action android:name="android.intent.action.MAIN"/>
         <category android:name="android.intent.category.LAUNCHER"/>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -3,4 +3,5 @@
   <string name="expo_splash_screen_resize_mode" translatable="false">contain</string>
   <string name="expo_splash_screen_status_bar_translucent" translatable="false">false</string>
   <string name="expo_system_ui_user_interface_style" translatable="false">light</string>
+  <string name="ExpoLocalization_supportsRTL" translatable="false">undefined</string>
 </resources>

--- a/app.json
+++ b/app.json
@@ -12,13 +12,8 @@
       "resizeMode": "contain",
       "backgroundColor": "#000000"
     },
-    "assetBundlePatterns": [
-      "**/*"
-    ],
-    "platforms": [
-      "ios",
-      "android"
-    ],
+    "assetBundlePatterns": ["**/*"],
+    "platforms": ["ios", "android"],
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.pixelfed",
@@ -57,9 +52,7 @@
             "NSExtensionActivationSupportsImageWithMaxCount": 1,
             "NSExtensionActivationSupportsMovieWithMaxCount": 1
           },
-          "androidIntentFilters": [
-            "image/*"
-          ]
+          "androidIntentFilters": ["image/*"]
         }
       ],
       [
@@ -81,9 +74,10 @@
         {
           "mode": "production",
           "icon": "./assets/notification-icon.png",
-          "color": "#ffffff" 
+          "color": "#ffffff"
         }
-      ]
+      ],
+      "expo-localization"
     ],
     "experiments": {
       "typedRoutes": true

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -30,6 +30,8 @@ PODS:
     - ExpoModulesCore
   - ExpoKeepAwake (12.8.2):
     - ExpoModulesCore
+  - ExpoLocalization (14.8.4):
+    - ExpoModulesCore
   - ExpoModulesCore (1.11.13):
     - glog
     - RCT-Folly (= 2022.05.16.00)
@@ -1203,6 +1205,7 @@ DEPENDENCIES:
   - ExpoHead (from `../node_modules/expo-router/ios`)
   - ExpoImagePicker (from `../node_modules/expo-image-picker/ios`)
   - ExpoKeepAwake (from `../node_modules/expo-keep-awake/ios`)
+  - ExpoLocalization (from `../node_modules/expo-localization/ios`)
   - ExpoModulesCore (from `../node_modules/expo-modules-core`)
   - ExpoSecureStore (from `../node_modules/expo-secure-store/ios`)
   - ExpoShareIntentModule (from `../node_modules/expo-share-intent/ios`)
@@ -1318,6 +1321,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/expo-image-picker/ios"
   ExpoKeepAwake:
     :path: "../node_modules/expo-keep-awake/ios"
+  ExpoLocalization:
+    :path: "../node_modules/expo-localization/ios"
   ExpoModulesCore:
     :path: "../node_modules/expo-modules-core"
   ExpoSecureStore:
@@ -1470,6 +1475,7 @@ SPEC CHECKSUMS:
   ExpoHead: 89ffd324e60520751c2c285233fe45e875c91874
   ExpoImagePicker: 66970181d1c838f444e5e1f81b804ab2d5ff49bd
   ExpoKeepAwake: 0f5cad99603a3268e50af9a6eb8b76d0d9ac956c
+  ExpoLocalization: f94759e55802e4a4f8b7d7cecb450de11b888721
   ExpoModulesCore: 4a8928a228569301ac4fc4a1e846713e05754d05
   ExpoSecureStore: c84ae37d1c36f38524d289c67c3a2e3fc56f1108
   ExpoShareIntentModule: d17e3800cac0945b8266dd61921e5e396c3aecb6

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "expo-haptics": "~12.8.1",
         "expo-image-picker": "~14.7.1",
         "expo-linking": "~6.2.2",
+        "expo-localization": "~14.8.4",
         "expo-notifications": "~0.27.8",
         "expo-router": "~3.4.10",
         "expo-secure-store": "~12.8.1",
@@ -39,6 +40,7 @@
         "expo-status-bar": "~1.11.1",
         "expo-system-ui": "~2.9.4",
         "expo-web-browser": "~12.8.2",
+        "i18n-js": "^4.5.1",
         "patch-package": "^8.0.0",
         "react": "18.2.0",
         "react-dom": "18.2.0",
@@ -9671,6 +9673,14 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/bignumber.js": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.2.tgz",
+      "integrity": "sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -11795,6 +11805,17 @@
         "invariant": "^2.2.4"
       }
     },
+    "node_modules/expo-localization": {
+      "version": "14.8.4",
+      "resolved": "https://registry.npmjs.org/expo-localization/-/expo-localization-14.8.4.tgz",
+      "integrity": "sha512-WWcG6Bg9s8p9wk5BvdXfxBLCEcvzS75O+nN5O+kWA3+cGDKcbfvExWmXcCSz8hn8y8rRVIEx8wwSgysMTtptUA==",
+      "dependencies": {
+        "rtl-detect": "^1.0.2"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
     "node_modules/expo-modules-autolinking": {
       "version": "1.10.3",
       "resolved": "https://registry.npmjs.org/expo-modules-autolinking/-/expo-modules-autolinking-1.10.3.tgz",
@@ -12949,6 +12970,16 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.1.0.tgz",
       "integrity": "sha512-WDC/ui2VVRrz3jOVi+XtjqkDjiVjTtFaAGiW37k6b+ohyQ5wYDOGkvCZa8+H0nx3gyvv0+BST9xuOgIyGQ00gw=="
+    },
+    "node_modules/i18n-js": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/i18n-js/-/i18n-js-4.5.1.tgz",
+      "integrity": "sha512-n7jojFj1WC0tztgr0I8jqTXuIlY1xNzXnC3mjKX/YjJhimdM+jXM8vOmn9d3xQFNC6qDHJ4ovhdrGXrRXLIGkA==",
+      "dependencies": {
+        "bignumber.js": "*",
+        "lodash": "*",
+        "make-plural": "*"
+      }
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
@@ -14720,6 +14751,11 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/make-plural": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/make-plural/-/make-plural-7.4.0.tgz",
+      "integrity": "sha512-4/gC9KVNTV6pvYg2gFeQYTW3mWaoJt7WZE5vrp1KnQDgW92JtYZnzmZT81oj/dUTqAIu0ufI2x3dkgu3bB1tYg=="
     },
     "node_modules/makeerror": {
       "version": "1.0.12",
@@ -18573,6 +18609,11 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/rtl-detect": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/rtl-detect/-/rtl-detect-1.1.2.tgz",
+      "integrity": "sha512-PGMBq03+TTG/p/cRB7HCLKJ1MgDIi07+QU1faSjiYRfmY5UsAttV9Hs08jDAHVwcOwmVLcSJkpwyfXszVjWfIQ=="
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -37,10 +37,13 @@
     "expo": "^50.0.14",
     "expo-application": "~5.8.4",
     "expo-constants": "~15.4.6",
+    "expo-device": "~5.9.4",
     "expo-font": "~11.10.3",
     "expo-haptics": "~12.8.1",
     "expo-image-picker": "~14.7.1",
     "expo-linking": "~6.2.2",
+    "expo-localization": "~14.8.4",
+    "expo-notifications": "~0.27.8",
     "expo-router": "~3.4.10",
     "expo-secure-store": "~12.8.1",
     "expo-share-intent": "^1.5.2",
@@ -48,6 +51,7 @@
     "expo-status-bar": "~1.11.1",
     "expo-system-ui": "~2.9.4",
     "expo-web-browser": "~12.8.2",
+    "i18n-js": "^4.5.1",
     "patch-package": "^8.0.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
@@ -70,9 +74,7 @@
     "react-native-web": "~0.19.6",
     "semver": ">=7.5.2",
     "tamagui": "^1.94.4",
-    "typescript": "^5.3.0",
-    "expo-notifications": "~0.27.8",
-    "expo-device": "~5.9.4"
+    "typescript": "^5.3.0"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/src/app/(auth)/settings/index.tsx
+++ b/src/app/(auth)/settings/index.tsx
@@ -145,6 +145,11 @@ export default function Page() {
               path="/settings/appearance/"
             />
             <GroupButton
+              icon="globe"
+              title={t('settingsScreen.language')}
+              path="/settings/language/"
+            />
+            <GroupButton
               icon="alert-triangle"
               title={t('settingsScreen.pushNotifications')}
               path="/settings/notifications/"
@@ -168,15 +173,6 @@ export default function Page() {
               path="settings/remove/request/permanent"
             />
           </Group>
-
-          <Group orientation="vertical" separator={<Separator borderColor="$gray2" />}>
-            <GroupButton
-              icon="globe"
-              title={t('settingsScreen.language')}
-              path="/settings/language/"
-            />
-          </Group>
-
           <Button bg="$gray1" justifyContent="flex-start" size="$5" px="$3">
             <XStack flexGrow={1} justifyContent="space-between" alignItems="center">
               <XStack alignItems="center" ml="$1" gap="$3">

--- a/src/app/(auth)/settings/index.tsx
+++ b/src/app/(auth)/settings/index.tsx
@@ -1,9 +1,9 @@
 import { Alert } from 'react-native'
 import { Group, ScrollView, Separator, Text, XStack, YStack, Button } from 'tamagui'
 import { Storage } from 'src/state/cache'
-import React, { useState, useEffect, useLayoutEffect } from 'react'
+import React, { useLayoutEffect } from 'react'
 import { SafeAreaView } from 'react-native-safe-area-context'
-import { Stack, Link, useNavigation } from 'expo-router'
+import { Stack, Link, useNavigation, type LinkProps } from 'expo-router'
 import { useAuth, useUserCache } from '@state/AuthProvider'
 import { openBrowserAsync } from 'src/utils'
 import * as Application from 'expo-application'
@@ -11,12 +11,11 @@ import {
   GroupButtonContent,
   type GroupButtonContentProps,
 } from 'src/components/common/GroupButtonContent'
-
+import { useI18n } from 'src/hooks/useI18n'
 export default function Page() {
   const navigation = useNavigation()
-  useLayoutEffect(() => {
-    navigation.setOptions({ title: 'Settings' })
-  }, [navigation])
+  const { t } = useI18n()
+
   const { username, locked } = useUserCache()
   const instance = Storage.getString('app.instance')
   const buildVersion = 74
@@ -40,9 +39,11 @@ export default function Page() {
     icon,
     title,
     path,
-  }: GroupButtonContentProps & { path: string }) => (
+  }: GroupButtonContentProps & {
+    path: string
+  }) => (
     <Group.Item>
-      <Link href={path} asChild>
+      <Link href={path as LinkProps<String>['href']} asChild>
         <Button bg="$gray1" justifyContent="flex-start" size="$5" px="$3">
           <GroupButtonContent icon={icon} title={title} iconColor="#666" />
         </Button>
@@ -69,22 +70,31 @@ export default function Page() {
   )
 
   const handleLogOut = () => {
-    Alert.alert('Confirm', 'Are you sure you want to log out of this account?', [
-      {
-        text: 'Cancel',
-      },
-      {
-        text: 'Log out',
-        style: 'destructive',
-        onPress: () => cacheClear(),
-      },
-    ])
+    Alert.alert(
+      t('settingsScreen.logoutModal.title'),
+      t('settingsScreen.logoutModal.message'),
+      [
+        {
+          text: t('settingsScreen.logoutModal.cancel'),
+        },
+        {
+          text: t('settingsScreen.logoutModal.confirm'),
+          style: 'destructive',
+          onPress: () => cacheClear(),
+        },
+      ]
+    )
   }
+
+  useLayoutEffect(() => {
+    navigation.setOptions({ title: t('settingsScreen.settings') })
+  }, [navigation])
+
   return (
     <SafeAreaView style={{ flex: 1 }} edges={['bottom']}>
       <Stack.Screen
         options={{
-          title: 'Settings',
+          title: t('settingsScreen.settings'),
           headerBackTitle: 'Back',
         }}
       />
@@ -93,7 +103,7 @@ export default function Page() {
           <Group orientation="vertical" separator={<Separator borderColor="$gray2" />}>
             <GroupButton
               icon="user"
-              title="Avatar, Bio and Display Name"
+              title={t('settingsScreen.avatarBioAndDisplayName')}
               path="/settings/profile"
             />
           </Group>
@@ -102,19 +112,23 @@ export default function Page() {
             {locked ? (
               <GroupButton
                 icon="user-plus"
-                title="Follow Requests"
+                title={t('settingsScreen.followRequests')}
                 path="/profile/follow-requests/"
               />
             ) : null}
-            <GroupButton icon="grid" title="Collections" path="/collections/" />
+            <GroupButton
+              icon="grid"
+              title={t('settingsScreen.collections')}
+              path="/collections/"
+            />
             <GroupButton
               icon="tag"
-              title="Followed Hashtags"
+              title={t('settingsScreen.followedHashtags')}
               path="/hashtag/followedTags"
             />
             <GroupButton
               icon="lock"
-              title="Privacy & Relationships"
+              title={t('settingsScreen.privacyAndRelationships')}
               path="/settings/privacy"
             />
           </Group>
@@ -122,13 +136,17 @@ export default function Page() {
           <Group orientation="vertical" separator={<Separator borderColor="$gray2" />}>
             <GroupButton
               icon="life-buoy"
-              title="Accessibility"
+              title={t('settingsScreen.accessibility')}
               path="/settings/accessibility/"
             />
-            <GroupButton icon="droplet" title="Appearance" path="/settings/appearance/" />
+            <GroupButton
+              icon="droplet"
+              title={t('settingsScreen.appearance')}
+              path="/settings/appearance/"
+            />
             <GroupButton
               icon="alert-triangle"
-              title="Push Notifications"
+              title={t('settingsScreen.pushNotifications')}
               path="/settings/notifications/"
             />
           </Group>
@@ -139,18 +157,30 @@ export default function Page() {
               title={instance || ''}
               path="/settings/instance/"
             />
-            <GroupButton icon="align-left" title="Legal" path="/settings/legal/" />
+            <GroupButton
+              icon="align-left"
+              title={t('settingsScreen.legal')}
+              path="/settings/legal/"
+            />
             <GroupUrlButton
               icon="trash"
-              title="Delete Account"
+              title={t('settingsScreen.deleteAccount')}
               path="settings/remove/request/permanent"
+            />
+          </Group>
+
+          <Group orientation="vertical" separator={<Separator borderColor="$gray2" />}>
+            <GroupButton
+              icon="globe"
+              title={t('settingsScreen.language')}
+              path="/settings/language/"
             />
           </Group>
 
           <Button bg="$gray1" justifyContent="flex-start" size="$5" px="$3">
             <XStack flexGrow={1} justifyContent="space-between" alignItems="center">
               <XStack alignItems="center" ml="$1" gap="$3">
-                <Text fontSize="$6">Version</Text>
+                <Text fontSize="$6">{t('settingsScreen.version')}</Text>
               </XStack>
               <Text fontSize="$6" color="$gray9">
                 {version}
@@ -159,7 +189,7 @@ export default function Page() {
           </Button>
 
           <Button bg="$red4" mt="$2" onPress={() => handleLogOut()}>
-            <Text>Log out {'@' + username}</Text>
+            <Text>{t('settingsScreen.logoutUsername', { username })}</Text>
           </Button>
         </YStack>
       </ScrollView>

--- a/src/app/(auth)/settings/language/index.tsx
+++ b/src/app/(auth)/settings/language/index.tsx
@@ -6,16 +6,14 @@ import React from 'react'
 import { Feather } from '@expo/vector-icons'
 import { useI18n } from 'src/hooks/useI18n'
 export default function Screen() {
-  const { locale, setLocale, t } = useI18n()
+  const { locale, setLocale, t, getLocaleLabel } = useI18n()
 
   const availableLocalesWithLabels = availableLocales
     .map((locale) => ({
-      label: t(`locales.${locale}`, {
-        defaultValue: locale,
-      }),
+      label: getLocaleLabel(locale),
       value: locale,
     }))
-    .sort((a, b) => a.label.localeCompare(b.label))
+    .sort((a, b) => a.label.translated.localeCompare(b.label.translated))
 
   return (
     <SafeAreaView edges={['bottom']}>
@@ -34,7 +32,8 @@ export default function Screen() {
                 onPress={() => {
                   setLocale(value)
                 }}
-                title={label}
+                title={label.translated}
+                subTitle={label.original}
                 iconAfter={
                   value === locale ? (
                     <Feather name="check-circle" color="green" size={16} />

--- a/src/app/(auth)/settings/language/index.tsx
+++ b/src/app/(auth)/settings/language/index.tsx
@@ -1,0 +1,50 @@
+import { ListItem, ScrollView, YGroup } from 'tamagui'
+import { SafeAreaView } from 'react-native-safe-area-context'
+import { Stack } from 'expo-router'
+import { availableLocales } from 'src/lib/i18n'
+import React from 'react'
+import { Feather } from '@expo/vector-icons'
+import { useI18n } from 'src/hooks/useI18n'
+export default function Screen() {
+  const { locale, setLocale, t } = useI18n()
+
+  const availableLocalesWithLabels = availableLocales
+    .map((locale) => ({
+      label: t(`locales.${locale}`, {
+        defaultValue: locale,
+      }),
+      value: locale,
+    }))
+    .sort((a, b) => a.label.localeCompare(b.label))
+
+  return (
+    <SafeAreaView edges={['bottom']}>
+      <Stack.Screen
+        options={{
+          title: t('settingsScreen.language'),
+          headerBackTitle: 'Back',
+        }}
+      />
+
+      <ScrollView flexShrink={1}>
+        <YGroup>
+          {availableLocalesWithLabels.map(({ value, label }) => (
+            <YGroup.Item key={value}>
+              <ListItem
+                onPress={() => {
+                  setLocale(value)
+                }}
+                title={label}
+                iconAfter={
+                  value === locale ? (
+                    <Feather name="check-circle" color="green" size={16} />
+                  ) : undefined
+                }
+              />
+            </YGroup.Item>
+          ))}
+        </YGroup>
+      </ScrollView>
+    </SafeAreaView>
+  )
+}

--- a/src/app/(public)/login.tsx
+++ b/src/app/(public)/login.tsx
@@ -15,10 +15,12 @@ import { useAuth } from '@state/AuthProvider'
 import { ActivityIndicator, Platform, SafeAreaView } from 'react-native'
 import { useEffect, useState } from 'react'
 import { StatusBar } from 'expo-status-bar'
+import { useI18n } from 'src/hooks/useI18n'
 
 export default function Login() {
   const [server, setServer] = useState('pixelfed.social')
   const [loading, setLoading] = useState(true)
+  const { t } = useI18n()
 
   const { login, isLoading } = useAuth()
 
@@ -69,7 +71,7 @@ export default function Login() {
                 fontWeight="bold"
                 flexGrow={1}
               >
-                Login
+                {t('login')}
               </Button>
             </Link>
           </YStack>

--- a/src/app/(public)/selectServer.tsx
+++ b/src/app/(public)/selectServer.tsx
@@ -18,6 +18,7 @@ import { getOpenServers } from 'src/lib/api'
 import { enforceLen, prettyCount } from 'src/utils'
 import FastImage from 'react-native-fast-image'
 import { PressableOpacity } from 'react-native-pressable-opacity'
+import { useI18n } from 'src/hooks/useI18n'
 
 export default function Register() {
   const { data } = useQuery({
@@ -28,6 +29,7 @@ export default function Register() {
   const router = useRouter()
 
   const { login, isLoading } = useAuth()
+  const { t } = useI18n()
 
   const [searchQuery, setSearchQuery] = useState('')
 
@@ -85,7 +87,10 @@ export default function Register() {
           </Text>
           <XStack gap="$2">
             <Text fontSize="$3" color="$gray5">
-              {prettyCount(item.user_count)} users
+              {t('users', {
+                count: item.user_count,
+                prettyCount: prettyCount(item.user_count),
+              })}
             </Text>
 
             <Text fontSize="$3" color="$gray10">
@@ -94,7 +99,7 @@ export default function Register() {
           </XStack>
         </YStack>
         <Text pr="$3" color="$blue8" fontWeight={'bold'}>
-          Login
+          {t('login')}
         </Text>
       </XStack>
     </Button>
@@ -106,14 +111,14 @@ export default function Register() {
       <Stack.Screen options={{ headerShown: false }} />
       <View justifyContent="center" alignItems="center" mb="$5">
         <Text fontSize={30} mt="$6" letterSpacing={-1} color="white">
-          Select your server
+          {t('selectServerScreen.selectYourServer')}
         </Text>
       </View>
       <View style={styles.searchContainer}>
         <Feather name="search" size={20} color="#000" style={styles.searchIcon} />
         <TextInput
           style={styles.searchInput}
-          placeholder="Search servers..."
+          placeholder={t('selectServerScreen.searchServerPlaceholder')}
           value={searchQuery}
           placeholderTextColor={'#999'}
           onChangeText={setSearchQuery}
@@ -135,7 +140,7 @@ export default function Register() {
             fontWeight="bold"
             py="$2"
           >
-            Tap here to login with a server domain
+            {t('selectServerScreen.tapHereToLoginWithAServerDomain')}
           </Text>
         </PressableOpacity>
       </View>

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -20,6 +20,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { VideoProvider } from 'src/hooks/useVideoProvider'
 import * as Notifications from 'expo-notifications'
 import Constants from 'expo-constants'
+import { I18nContextProvider } from './context/i18n/Provider'
 
 export const unstable_settings = {
   initialRouteName: '/login',
@@ -102,19 +103,21 @@ function RootLayoutNav() {
             <TamaguiProvider config={config} defaultTheme={'light'}>
               <ToastProvider native={true}>
                 <ThemeProvider value={DefaultTheme}>
-                  <VideoProvider>
-                    <Stack>
-                      <Stack.Screen
-                        name="(auth)/(tabs)"
-                        options={{ headerShown: false, backBehavior: 'order' }}
-                      />
-                      <Stack.Screen
-                        name="(public)/login"
-                        options={{ headerShown: false }}
-                      />
-                    </Stack>
-                    <ToastViewport />
-                  </VideoProvider>
+                  <I18nContextProvider>
+                    <VideoProvider>
+                      <Stack>
+                        <Stack.Screen
+                          name="(auth)/(tabs)"
+                          options={{ headerShown: false, backBehavior: 'order' }}
+                        />
+                        <Stack.Screen
+                          name="(public)/login"
+                          options={{ headerShown: false }}
+                        />
+                      </Stack>
+                      <ToastViewport />
+                    </VideoProvider>
+                  </I18nContextProvider>
                 </ThemeProvider>
               </ToastProvider>
             </TamaguiProvider>

--- a/src/app/context/i18n/Provider.tsx
+++ b/src/app/context/i18n/Provider.tsx
@@ -11,6 +11,26 @@ export const I18nContextProvider = ({ children }: PropsWithChildren) => {
     setLocaleHasChanged((state) => !state)
   }, [])
 
+  const getLocaleLabel = useCallback((locale: string) => {
+    const translated = i18n.t(`locales.${locale}`, {
+      defaultValue: locale,
+    })
+
+    const thisLocalTranslations = i18n.translations[locale]
+
+    if (!thisLocalTranslations) {
+      return { translated, original: locale }
+    }
+
+    const translatedLocalesOfThisLocale = thisLocalTranslations['locales']
+
+    if (!translatedLocalesOfThisLocale) {
+      return { translated, original: locale }
+    }
+
+    return { translated, original: translatedLocalesOfThisLocale[locale] ?? locale }
+  }, [])
+
   useEffect(() => {
     const unsubsribe = i18n.onChange((newVal) => {
       Storage.set(i18nLocaleStorageKey, newVal.locale)
@@ -25,6 +45,7 @@ export const I18nContextProvider = ({ children }: PropsWithChildren) => {
         locale: i18n.locale,
         setLocale,
         localeHasChanged,
+        getLocaleLabel,
         t: (...props) => i18n.t(...props),
       }}
     >

--- a/src/app/context/i18n/Provider.tsx
+++ b/src/app/context/i18n/Provider.tsx
@@ -1,0 +1,34 @@
+import { type PropsWithChildren, useCallback, useEffect, useState } from 'react'
+import { i18nContext } from './context'
+import { i18n, i18nLocaleStorageKey } from 'src/lib/i18n'
+import { Storage } from 'src/state/cache'
+
+export const I18nContextProvider = ({ children }: PropsWithChildren) => {
+  const [localeHasChanged, setLocaleHasChanged] = useState(false)
+
+  const setLocale = useCallback((newLocale: string) => {
+    i18n.locale = newLocale
+    setLocaleHasChanged((state) => !state)
+  }, [])
+
+  useEffect(() => {
+    const unsubsribe = i18n.onChange((newVal) => {
+      Storage.set(i18nLocaleStorageKey, newVal.locale)
+    })
+
+    return () => unsubsribe()
+  }, [])
+
+  return (
+    <i18nContext.Provider
+      value={{
+        locale: i18n.locale,
+        setLocale,
+        localeHasChanged,
+        t: (...props) => i18n.t(...props),
+      }}
+    >
+      {children}
+    </i18nContext.Provider>
+  )
+}

--- a/src/app/context/i18n/context.ts
+++ b/src/app/context/i18n/context.ts
@@ -1,0 +1,18 @@
+import { createContext } from 'react'
+import type { i18n } from 'src/lib/i18n'
+
+type I18nContextType = {
+  locale: string
+  setLocale: (locale: string) => void
+  localeHasChanged: boolean
+  t: typeof i18n.t
+}
+
+const defaultValue: I18nContextType = {
+  locale: 'en',
+  setLocale: () => {},
+  localeHasChanged: false,
+  t: () => '',
+}
+
+export const i18nContext = createContext<I18nContextType>(defaultValue)

--- a/src/app/context/i18n/context.ts
+++ b/src/app/context/i18n/context.ts
@@ -6,6 +6,7 @@ type I18nContextType = {
   setLocale: (locale: string) => void
   localeHasChanged: boolean
   t: typeof i18n.t
+  getLocaleLabel(locale: string): { translated: string; original: string }
 }
 
 const defaultValue: I18nContextType = {
@@ -13,6 +14,9 @@ const defaultValue: I18nContextType = {
   setLocale: () => {},
   localeHasChanged: false,
   t: () => '',
+  getLocaleLabel: () => {
+    return { translated: '', original: '' }
+  },
 }
 
 export const i18nContext = createContext<I18nContextType>(defaultValue)

--- a/src/hooks/useI18n.ts
+++ b/src/hooks/useI18n.ts
@@ -1,0 +1,4 @@
+import { useContext } from 'react'
+import { i18nContext } from 'src/app/context/i18n/context'
+
+export const useI18n = () => useContext(i18nContext)

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -5,10 +5,13 @@ import en from '../shared/translations/en.json'
 import ptBR from '../shared/translations/pt-BR.json'
 import { Storage } from 'src/state/cache'
 
+const defaultLocale = 'en'
+const locales = getLocales();
+
 export const i18n = new I18n()
 export const i18nLocaleStorageKey = 'ui.locale'
+export const i18nAppSettingsLocaleStorageKey = 'system.appSettingsLocale'
 export const availableLocales: string[] = []
-const defaultLocale = 'en'
 
 const findClosestLocale = (locale: string) => {
   const [language] = locale.split('-')
@@ -19,12 +22,15 @@ const findClosestLocale = (locale: string) => {
 }
 
 const getDeviceLocaleOrClosest = () => {
+  let locale = locales[0].languageTag
+  const storedAppSettingsLocale = Storage.getString(i18nAppSettingsLocaleStorageKey)
   const storedLocale = Storage.getString(i18nLocaleStorageKey)
 
-  if (storedLocale) {
-    return storedLocale
+  if(locale !== storedAppSettingsLocale) {
+    Storage.set(i18nAppSettingsLocaleStorageKey, locale)
+  }else if (storedLocale) {
+    locale = storedLocale
   }
-  const locale = getLocales()[0].languageTag
   return i18n.translations[locale] ? locale : findClosestLocale(locale)
 }
 

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -1,0 +1,38 @@
+import { getLocales } from 'expo-localization'
+import { I18n } from 'i18n-js'
+
+import en from '../shared/translations/en.json'
+import ptBR from '../shared/translations/pt-BR.json'
+import { Storage } from 'src/state/cache'
+
+export const i18nLocaleStorageKey = 'ui.locale'
+
+export const availableLocales = ['en', 'pt-BR']
+const defaultLocale = 'en'
+
+const findClosestLocale = (locale: string) => {
+  const [language] = locale.split('-')
+  const closestLocale = Object.keys(i18n.translations).find((key) =>
+    key.startsWith(language)
+  )
+  return closestLocale ?? defaultLocale
+}
+
+const getDeviceLocaleOrClosest = () => {
+  const storedLocale = Storage.getString(i18nLocaleStorageKey)
+
+  if (storedLocale) {
+    return storedLocale
+  }
+  const locale = getLocales()[0].languageTag
+  return i18n.translations[locale] ? locale : findClosestLocale(locale)
+}
+
+export const i18n = new I18n()
+
+i18n.store(en)
+i18n.store(ptBR)
+
+i18n.defaultLocale = defaultLocale
+i18n.enableFallback = true
+i18n.locale = getDeviceLocaleOrClosest()

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -1,13 +1,13 @@
 import { getLocales } from 'expo-localization'
-import { I18n } from 'i18n-js'
+import { type Dict, I18n } from 'i18n-js'
 
 import en from '../shared/translations/en.json'
 import ptBR from '../shared/translations/pt-BR.json'
 import { Storage } from 'src/state/cache'
 
+export const i18n = new I18n()
 export const i18nLocaleStorageKey = 'ui.locale'
-
-export const availableLocales = ['en', 'pt-BR']
+export const availableLocales: string[] = []
 const defaultLocale = 'en'
 
 const findClosestLocale = (locale: string) => {
@@ -28,10 +28,13 @@ const getDeviceLocaleOrClosest = () => {
   return i18n.translations[locale] ? locale : findClosestLocale(locale)
 }
 
-export const i18n = new I18n()
+const addLocale = (locale: string, translations: Dict) => {
+  i18n.store(translations)
+  availableLocales.push(locale)
+}
 
-i18n.store(en)
-i18n.store(ptBR)
+addLocale('en', en)
+addLocale('pt-BR', ptBR)
 
 i18n.defaultLocale = defaultLocale
 i18n.enableFallback = true

--- a/src/shared/translations/en.json
+++ b/src/shared/translations/en.json
@@ -1,0 +1,41 @@
+{
+  "en": {
+    "locales": {
+      "en": "English",
+      "pt-BR": "Portuguese (Brazil)"
+    },
+    "login": "Login",
+    "selectServerScreen": {
+      "searchServerPlaceholder": "Search servers...",
+      "selectYourServer": "Select your server",
+      "tapHereToLoginWithAServerDomain": "Tap here to login with a server domain"
+    },
+    "settingsScreen": {
+      "accessibility": "Accessibility",
+      "appearance": "Appearance",
+      "avatarBioAndDisplayName": "Avatar, Bio and Display Name",
+      "collections": "Collections",
+      "deleteAccount": "Delete account",
+      "followedHashtags": "Followed hashtags",
+      "followRequests": "Follow request",
+      "language": "Language",
+      "legal": "Legal",
+      "logoutModal": {
+        "cancel": "Cancel",
+        "confirm": "Log out",
+        "message": "Are you sure you want to log out of this account?",
+        "title": "Confirm"
+      },
+      "logoutUsername": "Logout @%{username}",
+      "privacyAndRelationships": "Privacy & Relationships",
+      "pushNotifications": "Push notifications",
+      "settings": "Settings",
+      "version": "Version"
+    },
+    "users": {
+      "one": "1 user",
+      "other": "%{prettyCount} users",
+      "zero": "No users"
+    }
+  }
+}

--- a/src/shared/translations/pt-BR.json
+++ b/src/shared/translations/pt-BR.json
@@ -1,0 +1,41 @@
+{
+  "pt-BR": {
+    "locales": {
+      "en": "Inglês",
+      "pt-BR": "Português (Brasil)"
+    },
+    "login": "Entrar",
+    "selectServerScreen": {
+      "searchServerPlaceholder": "Procurar servidores...",
+      "selectYourServer": "Selecione seu servidor",
+      "tapHereToLoginWithAServerDomain": "Toque aqui para fazer login com um domínio de servidor"
+    },
+    "settingsScreen": {
+      "accessibility": "Acessibilidade",
+      "appearance": "Aparência",
+      "avatarBioAndDisplayName": "Avatar, Bio e nome visível",
+      "collections": "Coleções",
+      "deleteAccount": "Excluir conta",
+      "followedHashtags": "Hashtags seguidas",
+      "followRequests": "Solicitações de seguir",
+      "language": "Idioma",
+      "legal": "Legal",
+      "logoutModal": {
+        "cancel": "Cancelar",
+        "confirm": "Sair",
+        "message": "Tem certeza de que deseja sair desta conta?",
+        "title": "Confirmar"
+      },
+      "logoutUsername": "Sair @%{username}",
+      "privacyAndRelationships": "Privacidade e relacionamentos",
+      "pushNotifications": "Notificações push",
+      "settings": "Configurações",
+      "version": "Versão"
+    },
+    "users": {
+      "one": "1 usuário",
+      "other": "%{prettyCount} usuários",
+      "zero": "Nenhum usuário"
+    }
+  }
+}


### PR DESCRIPTION
The web version has translations, but the app isn't right now. Even if it is only available in English, it would be nice to make the app ready to translate in the future. 
In my opinion, it is better to do it as soon as possible when fewer screens and components are done to avoid a bigger refactor in the future

This can be done easily using `expo-localization` (https://docs.expo.dev/versions/latest/sdk/localization/) and `i18n-js` (https://www.npmjs.com/package/i18n-js).

I made some tests adding the i18n lib, the translation files for `en` and `pt-BR`, and refactoring the login and settings screens to use it


## Test on Android device

![Screen_Recording_20250128_101344_Pixelfed](https://github.com/user-attachments/assets/b982d674-5d1c-4490-bc54-0295df8c91a8)


## Test on iOS Simulator

![Simulator Screen Recording - iPhone 16 Pro - 2025-01-28 at 13 24 45](https://github.com/user-attachments/assets/fadd65cd-4c02-4133-b013-54af8d4f3d27)

closes #174