### PR TITLE
Set absolute line height in `FeedHeader` to avoid jump

### DIFF
--- a/src/components/common/FeedHeader.tsx
+++ b/src/components/common/FeedHeader.tsx
@@ -19,6 +19,7 @@ export default function FeedHeader({ title = 'Home', user }) {
       <XStack alignItems="center" gap="$1">
         <Text
           fontSize={title === 'Pixelfed' ? 25 : 19}
+          lineHeight={30}
           fontWeight="bold"
           letterSpacing={-0.5}
           allowFontScaling={false}


### PR DESCRIPTION
In the current app, switching between "Home" and the "Local Feed" makes the header height jump a few pixels, because the height is linked to the font size, but that differs between the two screens.

The easiest way to fix this is to set a common line height. For the 25px "Pixelfed" text, the line height was 30, so I hardcoded that so that it also applies to the "Local Feed".

# Before:

![Simulator Screenshot - iPhone 16 - 2025-02-09 at 00 11 52 2](https://github.com/user-attachments/assets/6724881a-31e9-402a-8a81-b6c87820cb66)

# After:

![Simulator Screenshot - iPhone 16 - 2025-02-09 at 00 11 52](https://github.com/user-attachments/assets/4b5f80f9-ac8c-441f-abf5-d65412805548)
