### PR TITLE
continue migration to api context

### DIFF
--- a/src/app/(auth)/hashtag/[id].tsx
+++ b/src/app/(auth)/hashtag/[id].tsx
@@ -65,7 +65,7 @@ export default function Page() {
             {relatedTags.map((tag) => (
               <Link key={tag.name} href={`/hashtag/${tag.name}`} asChild>
                 <View bg="$gray6" px="$3" py="$2" mr="$2" borderRadius={10}>
-                  <Text>{tag.name}</Text>
+                  <Text>#{tag.name}</Text>
                 </View>
               </Link>
             ))}

--- a/src/app/(auth)/hashtag/[id].tsx
+++ b/src/app/(auth)/hashtag/[id].tsx
@@ -118,7 +118,7 @@ export default function Page() {
 
   const { data: hashtag, isPending } = useQuery({
     queryKey: ['getHashtagByName', id],
-    queryFn: getHashtagByName,
+    queryFn: () => getHashtagByName(id),
   })
 
   const {
@@ -135,6 +135,7 @@ export default function Page() {
   } = useInfiniteQuery({
     queryKey: ['getHashtagByNameFeed', id],
     queryFn: async ({ pageParam }) => {
+      console.log({ pageParam })
       const data = await getHashtagByNameFeed(id, pageParam)
 
       return data.data?.filter((p) => {

--- a/src/lib/api-context.ts
+++ b/src/lib/api-context.ts
@@ -37,6 +37,10 @@ export class ApiContext {
       }
     }
 
+    // Tell the API that we want the extra pixelfed specific fields
+    // (that would not be in the mastodon api)
+    url.searchParams.append("_pe", "1")
+
     fetch_options.headers = {
       ...fetch_options.headers,
       Accept: 'application/json',

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -362,26 +362,24 @@ export async function getHashtagByNameFeed(id: string, page: number) {
 }
 
 export async function getHashtagRelated(id: string) {
-  const instance = Storage.getString('app.instance')
-  let url = `https://${instance}/api/v1/tags/${id}/related`
-  return await fetchPaginatedData(url)
+  const api = ContextFromStorage()
+  // TODO do we need pagination here? it is not used currently
+  return await api.getPaginated(`api/v1/tags/${id}/related`)
 }
 
 export async function getConversations() {
-  const instance = Storage.getString('app.instance')
-  let url = `https://${instance}/api/v1/conversations`
-  return await fetchData(url)
+  const api = ContextFromStorage()
+  return await api.get('api/v1/conversations')
 }
 
 export async function getComposeSettings() {
-  const path = `api/v1.1/compose/settings`
-  return await selfGet(path)
+  const api = ContextFromStorage()
+  return await api.get('api/v1.1/compose/settings')
 }
 
 export async function getConfig() {
-  const instance = Storage.getString('app.instance')
-  let url = `https://${instance}/api/v2/config`
-  return await fetchData(url)
+  const api = ContextFromStorage()
+  return await api.get('api/v2/config')
 }
 
 export async function getStatusRepliesById(id: string, page) {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -343,21 +343,26 @@ export async function getAccountStatusesById(
 ): Promise<Status[]> {
   const api = ContextFromStorage()
   return await api.get(`api/v1/accounts/${id}/statuses`, {
-    _pe: 1, // todo document what _pe means
+    _pe: 1, // TODO: document what _pe means
     ...parameters,
   })
 }
 
-export async function getHashtagByName({ queryKey }) {
-  const instance = Storage.getString('app.instance')
-  const url = `https://${instance}/api/v1/tags/${queryKey[1]}/?_pe=1`
-  return await fetchData(url)
+export async function getHashtagByName(id: string) {
+  const api = ContextFromStorage()
+  return await api.get(`api/v1/tags/${id}/`, {
+    _pe: 1, // TODO: document what _pe means
+  })
 }
 
-export async function getHashtagByNameFeed(id: string, page) {
-  const instance = Storage.getString('app.instance')
-  let url = `https://${instance}/api/v1/timelines/tag/${id}?_pe=1&max_id=${page}`
-  return await fetchPaginatedData(url)
+export async function getHashtagByNameFeed(id: string, page: number) {
+  const api = ContextFromStorage()
+  return await api.getPaginated(`/api/v1/timelines/tag/${id}`,
+    {
+      _pe: 1, // TODO: document what _pe means,
+      max_id: page
+    }
+  )
 }
 
 export async function getHashtagRelated(id: string) {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -282,12 +282,12 @@ export async function getAccountFollowing(id: string, cursor) {
 
 export async function getStatusById(id: string) {
   const api = ContextFromStorage()
-  return await api.get(`api/v1/statuses/${id}?_pe=1`)
+  return await api.get(`api/v1/statuses/${id}`)
 }
 
 export async function getAccountById(id: string) {
   const api = ContextFromStorage()
-  return await api.get(`api/v1/accounts/${id}?_pe=1`)
+  return await api.get(`api/v1/accounts/${id}`)
 }
 
 export async function followAccountById(
@@ -318,7 +318,7 @@ export async function report(report: NewReport) {
 
 export async function getAccountByUsername(username: string): Promise<Account> {
   const api = ContextFromStorage()
-  let account = await api.get(`api/v1.1/accounts/username/${username}?_pe=1`)
+  let account = await api.get(`api/v1.1/accounts/username/${username}`)
   if (Array.isArray(account) && account.length === 0) {
     throw new Error(`Account "${username}" not found`)
   }
@@ -343,23 +343,19 @@ export async function getAccountStatusesById(
 ): Promise<Status[]> {
   const api = ContextFromStorage()
   return await api.get(`api/v1/accounts/${id}/statuses`, {
-    _pe: 1, // TODO: document what _pe means
     ...parameters,
   })
 }
 
 export async function getHashtagByName(id: string) {
   const api = ContextFromStorage()
-  return await api.get(`api/v1/tags/${id}/`, {
-    _pe: 1, // TODO: document what _pe means
-  })
+  return await api.get(`api/v1/tags/${id}/`)
 }
 
 export async function getHashtagByNameFeed(id: string, page: number) {
   const api = ContextFromStorage()
   return await api.getPaginated(`/api/v1/timelines/tag/${id}`,
     {
-      _pe: 1, // TODO: document what _pe means,
       max_id: page
     }
   )


### PR DESCRIPTION
- **migrate `getHashtagByName` & `getHashtagByNameFeed` to `ApiContext`**
- **insert `_pe=1` into all requests made by the `ApiContext`**
- **fix that related hashtags were not prefixed with '#' character**
- **migrate `getConversations`, `getComposeSettings` and `getConfig` to use `ApiContext`**
