### PR TITLE
[Small Fix] Auto refresh data in feed when you click on icon to go up

### DIFF
--- a/src/app/(auth)/(tabs)/index.tsx
+++ b/src/app/(auth)/(tabs)/index.tsx
@@ -90,6 +90,7 @@ export default function HomeScreen() {
     useCallback(() => {
       const unsubscribe = navigation.addListener('tabPress', () => {
         flatListRef.current?.scrollToOffset({ animated: true, offset: 0 })
+        refetch();
       })
 
       return unsubscribe

--- a/src/app/(auth)/(tabs)/network.tsx
+++ b/src/app/(auth)/(tabs)/network.tsx
@@ -64,6 +64,7 @@ export default function HomeScreen() {
     useCallback(() => {
       const unsubscribe = navigation.addListener('tabPress', () => {
         flatListRef.current?.scrollToOffset({ animated: true, offset: 0 })
+        refetch();
       })
 
       return unsubscribe


### PR DESCRIPTION
Auto refresh data in feed when you click on icon to go up

- Added feature to refresh the network and home feed when user is already on the tab and clicks to go at the top.

Closes: #258 

### iOS Simulator 

https://github.com/user-attachments/assets/2c641464-89c1-4391-aed0-0372c52aaddc

### Android Simulator 


https://github.com/user-attachments/assets/ad3295a0-485c-4abf-b212-a7b39324fbf3



