### PR TITLE
Fixed back navigation order

### DIFF
--- a/src/app/(auth)/(tabs)/_layout.tsx
+++ b/src/app/(auth)/(tabs)/_layout.tsx
@@ -22,7 +22,7 @@ export default function AppLayout() {
   return (
     <Tabs
       initialRouteName={TabName.Index}
-      backBehavior="order"
+      backBehavior="history"
       screenOptions={{
         tabBarStyle: {
           height: 70,


### PR DESCRIPTION
# Changes

You can't really tell by the recording, but what causes tab switching after the first tab switch are back button presses.

**Before**
https://github.com/user-attachments/assets/43fdd8a5-8181-4952-a502-d0945c6a1f57

**After**
https://github.com/user-attachments/assets/6e147c0b-cf64-41b9-9e69-073d0ff873ad