### PR TITLE
Fixed splash screen configuration

### DIFF
--- a/app.json
+++ b/app.json
@@ -8,8 +8,7 @@
     "scheme": "pixelfed",
     "userInterfaceStyle": "automatic",
     "splash": {
-      "image": "./assets/splash.png",
-      "resizeMode": "contain",
+      "image": "./assets/adaptive-icon.png",
       "backgroundColor": "#000000"
     },
     "assetBundlePatterns": [

--- a/assets/splash.png
+++ b/assets/splash.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d7c9d2e0ecc2ce251a9c5146115f05f4a096c7dda85e345e69dc174eaf0e9b63
-size 19764


### PR DESCRIPTION
# Changes
Simplified the splash screen setup, which also fixes an issue on Android, where the icon would be very small on HDPI screens. It is now set up in the way recommended by the official expo guide.

| **Before** | **After** |
| ----------------- | ------------- |
| [before.webm](https://github.com/user-attachments/assets/a0f480ad-64d8-4f14-bce9-46763fb9d688) | [after.webm](https://github.com/user-attachments/assets/30cf2e2a-6a17-4598-a93a-ad50d5f02e7e) |

# Blockers
Please test iOS before merging, I haven't tested iOS. This has to be tested in release mode, since the splash screen is managed by expo in debug mode (on Android I had to manually build the release APK and then install it on the test device).

# Related issues
Closes #318 

