### PR TITLE
[UI Improvement] Removed border for the feedpost UI

### DIFF
--- a/src/components/post/FeedPost.tsx
+++ b/src/components/post/FeedPost.tsx
@@ -195,8 +195,7 @@ const PostHeader = React.memo(
           justifyContent="space-between"
           alignSelf="stretch"
           alignItems="center"
-          pt="$4"
-          pb="$2"
+          py="$2"
         >
           <View flexGrow={1}>
             <Link href={`/profile/${userId}`} asChild>
@@ -669,7 +668,7 @@ const PostCaption = React.memo(
     const theme = useTheme()
     return (
       <BorderlessSection>
-        <YStack gap="$3" pt="$1" pb="$3" px="$2">
+        <YStack gap="$3" pt="$1" pb="$5" px="$2">
           <XStack flexWrap="wrap" pr="$3">
             {disableReadMore ? (
               <AutolinkText

--- a/src/components/post/FeedPost.tsx
+++ b/src/components/post/FeedPost.tsx
@@ -149,6 +149,7 @@ const Section = React.memo(({ children }: React.PropsWithChildren) => {
   return (
     <View
       px="$3"
+      py="$1"
       backgroundColor={theme.background?.val.default.val}
     >
       {children}

--- a/src/components/post/FeedPost.tsx
+++ b/src/components/post/FeedPost.tsx
@@ -150,9 +150,6 @@ const Section = React.memo(({ children }: React.PropsWithChildren) => {
     <View
       px="$3"
       backgroundColor={theme.background?.val.default.val}
-      borderTopWidth={1}
-      borderBottomWidth={1}
-      borderColor={theme.borderColor.val.default.val}
     >
       {children}
     </View>
@@ -475,7 +472,7 @@ const PostActions = React.memo(
       Alert.alert(
         'Alt Text',
         post?.media_attachments[idx].description ??
-          'Media was not tagged with any alt text.'
+        'Media was not tagged with any alt text.'
       )
     }
     const theme = useTheme()
@@ -966,7 +963,7 @@ const FeedPost = React.memo(
     const handlePresentModalPress = useCallback(() => {
       bottomSheetModalRef.current?.present()
     }, [])
-    const handleSheetChanges = useCallback((_: number) => {}, [])
+    const handleSheetChanges = useCallback((_: number) => { }, [])
     const renderBackdrop = useCallback(
       (props: BottomSheetBackdropProps) => (
         <BottomSheetBackdrop {...props} disappearsOnIndex={-1} appearsOnIndex={1} />
@@ -1059,7 +1056,7 @@ const FeedPost = React.memo(
         await Share.share({
           message: post.url || post.uri,
         })
-      } catch (error) {}
+      } catch (error) { }
     }
     return (
       <View flex={1} style={{ width }}>

--- a/src/components/post/FeedPost.tsx
+++ b/src/components/post/FeedPost.tsx
@@ -147,11 +147,7 @@ const AVATAR_WIDTH = 45
 const Section = React.memo(({ children }: React.PropsWithChildren) => {
   const theme = useTheme()
   return (
-    <View
-      px="$3"
-      py="$1"
-      backgroundColor={theme.background?.val.default.val}
-    >
+    <View px="$3" py="$1" backgroundColor={theme.background?.val.default.val}>
       {children}
     </View>
   )
@@ -199,7 +195,8 @@ const PostHeader = React.memo(
           justifyContent="space-between"
           alignSelf="stretch"
           alignItems="center"
-          py="$2"
+          pt="$4"
+          pb="$2"
         >
           <View flexGrow={1}>
             <Link href={`/profile/${userId}`} asChild>
@@ -473,7 +470,7 @@ const PostActions = React.memo(
       Alert.alert(
         'Alt Text',
         post?.media_attachments[idx].description ??
-        'Media was not tagged with any alt text.'
+          'Media was not tagged with any alt text.'
       )
     }
     const theme = useTheme()
@@ -964,7 +961,7 @@ const FeedPost = React.memo(
     const handlePresentModalPress = useCallback(() => {
       bottomSheetModalRef.current?.present()
     }, [])
-    const handleSheetChanges = useCallback((_: number) => { }, [])
+    const handleSheetChanges = useCallback((_: number) => {}, [])
     const renderBackdrop = useCallback(
       (props: BottomSheetBackdropProps) => (
         <BottomSheetBackdrop {...props} disappearsOnIndex={-1} appearsOnIndex={1} />
@@ -1057,7 +1054,7 @@ const FeedPost = React.memo(
         await Share.share({
           message: post.url || post.uri,
         })
-      } catch (error) { }
+      } catch (error) {}
     }
     return (
       <View flex={1} style={{ width }}>


### PR DESCRIPTION
# Changes
<!-- Please describe any changes you have made and how they influence the app -->
- Removed border for feedpost UI. 
- Added padding at the bottom of the post to as suggested by the UI team.
# Blockers
<!-- Is there anything you need the team to do, before this can be merged? -->
NA
# Related issues
<!-- Please list all the issues that this fixes/is related to -->
NA

# Screenshot 


| Before | After | 
| - | - |
| <img width="370" alt="DarkBefore" src="https://github.com/user-attachments/assets/6209489a-0b01-4f82-a233-e2de3daef997" /> | <img width="370" alt="DarkAfter" src="https://github.com/user-attachments/assets/28c8e2f4-351b-46f7-93eb-203666ea2364" /> |
| <img width="370" alt="LightBefore" src="https://github.com/user-attachments/assets/f83b557f-5b10-4469-bcf7-1462152c8e22" /> | <img width="370" alt="LightAfter" src="https://github.com/user-attachments/assets/eb8512a7-4c46-4be7-a1ae-52265be599a3" /> |
| <img width="370" alt="StaleBefore" src="https://github.com/user-attachments/assets/df610f1b-f17b-43ed-a09c-bc2c8c01690c" /> | <img width="370" alt="StaleAfter" src="https://github.com/user-attachments/assets/3481029e-9700-4b7e-9d54-92cd079da66a" /> |
| <img width="370" alt="PinkBefore" src="https://github.com/user-attachments/assets/8b31c410-858d-475b-81f1-1c8a64949347" /> | <img width="370" alt="PinkAfter" src="https://github.com/user-attachments/assets/48f618a1-7744-4daa-93ac-9cf6b084133d" /> |
