### PR TITLE
Fixed Lint update that crashes the app

### DIFF
--- a/src/app/(auth)/post/comments/[id].tsx
+++ b/src/app/(auth)/post/comments/[id].tsx
@@ -471,7 +471,7 @@ export default function CommentsScreen() {
       setChildComments((prevChildComments) => {
         if (prevChildComments && typeof prevChildComments === 'object') {
           for (const key in prevChildComments) {
-            if (prevChildComments.hasOwn(key)) {
+            if (Object.prototype.hasOwnProperty.call(prevChildComments, key)) {
               const value = prevChildComments[key]
               if (Array.isArray(value)) {
                 prevChildComments[key] = value.filter(

--- a/src/app/(auth)/post/comments/[id].tsx
+++ b/src/app/(auth)/post/comments/[id].tsx
@@ -83,7 +83,7 @@ export default function CommentsScreen() {
       setChildComments((prevChildComments) => {
         if (prevChildComments && typeof prevChildComments === 'object') {
           for (const key in prevChildComments) {
-            if (prevChildComments.hasOwn(key)) {
+            if (Object.prototype.hasOwnProperty.call(prevChildComments, key)) {
               const value = prevChildComments[key]
               if (Array.isArray(value)) {
                 prevChildComments[key] = prevChildComments[key].map((item) => {

--- a/src/components/common/ZoomableImage.tsx
+++ b/src/components/common/ZoomableImage.tsx
@@ -44,6 +44,8 @@ const PinchZoomImage = ({ source, style, placeholder }) => {
             },
           ]}
           placeholder={placeholder}
+          cachePolicy="memory"
+          priority="high"
         />
       </Animated.View>
     </PinchGestureHandler>


### PR DESCRIPTION
# Changes
<!-- Please describe any changes you have made and how they influence the app -->
- Fixed Lint update that crashes the app

Details:
- There was a change introduced because of the biome linting [here](https://github.com/pixelfed/pixelfed-rn/commit/f5b1982695178afc97d9901483b389d36ad23bf8#diff-10084e31242dc6e7726e3bfd188114a960456f179df6cd2bb92f89e811a06e60R86) that crashes the app when moving between comment routes. 
- This PR fixes that issue and lint error as well. 
# Blockers
<!-- Is there anything you need the team to do, before this can be merged? -->
- NA
# Related issues
<!-- Please list all the issues that this fixes/is related to -->
| Before | After | 
| - | - |
| <video src="https://github.com/user-attachments/assets/5cab03ca-9fe8-425f-a534-7276bbf8523b"/> | <video src="https://github.com/user-attachments/assets/450d6732-cf37-4c07-a1f5-a4f55f1d0967"/> |
