### PR TITLE
[Bug fix] Alt button contrast fix

### DIFF
--- a/src/components/post/FeedPost.tsx
+++ b/src/components/post/FeedPost.tsx
@@ -602,11 +602,11 @@ const PostActions = React.memo(
               ) : null}
               {showAltText && hasAltText ? (
                 <PressableOpacity onPress={() => onShowAlt()}>
-                  <XStack bg="black" px="$3" py={4} borderRadius={5}>
+                  <XStack bg={theme.color?.val.default.val} px="$3" py={4} borderRadius={5}>
                     <Text
-                      color={theme.color?.val.default.val}
-                      fontSize="$5"
-                      fontWeight="bold"
+                        color={theme.color?.val.inverse.val}
+                        fontSize="$5"
+                        fontWeight="bold"
                     >
                       ALT
                     </Text>

--- a/src/components/post/FeedPost.tsx
+++ b/src/components/post/FeedPost.tsx
@@ -604,9 +604,9 @@ const PostActions = React.memo(
                 <PressableOpacity onPress={() => onShowAlt()}>
                   <XStack bg={theme.color?.val.default.val} px="$3" py={4} borderRadius={5}>
                     <Text
-                        color={theme.color?.val.inverse.val}
-                        fontSize="$5"
-                        fontWeight="bold"
+                      color={theme.color?.val.inverse.val}
+                      fontSize="$5"
+                      fontWeight="bold"
                     >
                       ALT
                     </Text>


### PR DESCRIPTION
# Changes
Used the default color theme for the background of the **ALT** button and then the inverse for the text. That way the contrast should always be fine :). Could probably improve the styling some more but this makes the button text visible at all times atleast.

### Old 
<img src="https://github.com/user-attachments/assets/9db601e7-d512-481d-8183-6b5e20a8f177" width="150"/>
<img src="https://github.com/user-attachments/assets/1f5aec79-723b-4138-b0ba-9f0f5d7b03a8" width="150"/>
<img src="https://github.com/user-attachments/assets/b3a20d54-68c8-4c84-b22e-7a51a7e76816" width="150"/>
<img src="https://github.com/user-attachments/assets/886c9830-f1b3-4c5d-8856-62bc3c96c1cb" width="150"/>
<img src="https://github.com/user-attachments/assets/3e4ebd3f-3178-4ef2-8b8b-a402f3b18fb7" width="150"/>

### New
<img src="https://github.com/user-attachments/assets/358bbe82-7e4a-4fff-8a36-8833237c38bb" width="150"/>
<img src="https://github.com/user-attachments/assets/66868548-3416-424b-894f-9efca9354bc6" width="150"/>
<img src="https://github.com/user-attachments/assets/ac9e7c94-3daf-4268-b829-17c273db0c5f" width="150"/>
<img src="https://github.com/user-attachments/assets/b598d99f-e6ac-4c88-bfb5-39821332ccc1" width="150"/>
<img src="https://github.com/user-attachments/assets/95d3db92-d2df-442c-ab13-1df5e04487bd" width="150"/>



# Blockers
 N/A

# Related issues
Fixes #338 
