### PR TITLE
Display profile on avatar click in chat

### DIFF
--- a/src/app/(auth)/chats/conversation/[id].tsx
+++ b/src/app/(auth)/chats/conversation/[id].tsx
@@ -300,6 +300,11 @@ export default function Page() {
         }}
         onSend={(messages) => onSend(messages)}
         maxInputLength={500}
+        onPressAvatar={
+            (user) => {
+                  router.push(`/profile/${user['_id']}`)
+            }
+        }
         lightboxProps={{
           activeProps: {
             style: {


### PR DESCRIPTION
# Changes
<!-- Please describe any changes you have made and how they influence the app -->

I liked the idea of this feature. So I created a PR for it. You can close it if you have something else in mind.

When clicking on the profile picture in the DM chat, it will now redirect to the users profile page.

https://github.com/user-attachments/assets/31c38e18-8cf2-4cae-b81c-44f079d94dad


# Blockers
<!-- Is there anything you need the team to do, before this can be merged? -->
N/A

# Related issues
<!-- Please list all the issues that this fixes/is related to -->
https://github.com/pixelfed/pixelfed-rn/issues/375

