### PR TITLE
Adjust height and size of pagination dots

### DIFF
--- a/src/components/post/FeedPost.tsx
+++ b/src/components/post/FeedPost.tsx
@@ -411,10 +411,10 @@ const PostAlbumMedia = React.memo(({ media, post, progress }: PostAlbumMediaProp
           gap: 2,
           position: 'absolute',
           bottom: 0,
-          marginBottom: -30,
+          marginBottom: -10,
           zIndex: 10,
         }}
-        size={8}
+        size={7}
       />
     </YStack>
   )


### PR DESCRIPTION
# Changes
<!-- Please describe any changes you have made and how they influence the app -->
Adjusted the height and size for the carousel dots when viewing multiple images. So that the dots don't overlapp the buttons.

**Before:**

https://github.com/user-attachments/assets/d707799f-6e41-4cd3-8414-ca2a2c227385

**After:**

https://github.com/user-attachments/assets/215560e1-bd6e-4b6f-849c-06c233a4c7d5


# Blockers
<!-- Is there anything you need the team to do, before this can be merged? -->
N/A

# Related issues
<!-- Please list all the issues that this fixes/is related to -->
Fixes: #336

