### PR TITLE
fix(android): browse option in photo picker missing

### DIFF
--- a/src/app/(auth)/(tabs)/camera.tsx
+++ b/src/app/(auth)/(tabs)/camera.tsx
@@ -213,6 +213,7 @@ export default function Camera() {
       quality: 1,
       orderedSelection: true,
       exif: false,
+      legacy: true,
     })
 
     if (!result.canceled) {

--- a/src/app/(auth)/settings/profile.tsx
+++ b/src/app/(auth)/settings/profile.tsx
@@ -94,6 +94,7 @@ export default function ProfilePage() {
       exif: false,
       selectionLimit: 1,
       quality: 0.5,
+      legacy: true,
     })
 
     if (!result.canceled) {

--- a/src/app/(public)/verifyEmail.tsx
+++ b/src/app/(public)/verifyEmail.tsx
@@ -293,6 +293,7 @@ const WelcomeStep = ({ onSubmit, isLoading, domain }) => {
       exif: false,
       selectionLimit: 1,
       quality: 0.5,
+      legacy: true,
     })
 
     if (!result.canceled) {


### PR DESCRIPTION
# Changes
<!-- Please describe any changes you have made and how they influence the app -->
- **Refactored** `ImagePicker.launchImageLibraryAsync` options to **reintroduce the "Browse" option** in Android.
- Users can now:
  - 📸 Select images directly from the **device's image library**.
  - 📂 **Browse and pick images** from any other location within the **mobile storage**.
- This enhancement improves **flexibility** and provides a **better user experience** when selecting images.

Before
<img width="453" height="319" alt="image" src="https://github.com/user-attachments/assets/1c063386-83b4-4839-ba40-983b34ac7bf4" />


After
<img width="450" height="345" alt="image" src="https://github.com/user-attachments/assets/e16a0725-7050-40d0-8292-49e321309713" />



# Blockers
<!-- Is there anything you need the team to do, before this can be merged? -->
No blockers

# Related issues
<!-- Please list all the issues that this fixes/is related to -->
Fixes #373

