### PR TITLE
fix: log out on expired tokens by setting the global logout function

### DIFF
--- a/src/state/AuthProvider.tsx
+++ b/src/state/AuthProvider.tsx
@@ -6,6 +6,7 @@ import { useContext, useState } from 'react'
 import { Alert, Platform } from 'react-native'
 import { get, loginPreflightCheck, postForm, verifyCredentials } from 'src/requests'
 import { Storage } from './cache'
+import { setGlobalLogoutFunction } from 'src/lib/api-context'
 
 import { useQuery } from '@tanstack/react-query'
 import type { ReactNode } from 'react'
@@ -284,6 +285,11 @@ export default function AuthProvider({ children }: { children: ReactNode }) {
     setUserCache(null)
     setIsLoading(false)
   }
+
+  // Register global logout function for ApiContext 401/403 handling
+  useEffect(() => {
+    setGlobalLogoutFunction(logout)
+  }, [logout])
 
   useProtectedRoute(user, setUser, setIsLoading)
 


### PR DESCRIPTION
# Changes

Currently if the auth token is expired, the application starts failing silently, and logging an error about an unset global out handler.

This change sets the global logout function, so unexpired credentials will force the user to reauthenticate.

