### PR TITLE
fix Follow Requested button colour

### DIFF
--- a/src/components/profile/actionButtons/FollowRequested.tsx
+++ b/src/components/profile/actionButtons/FollowRequested.tsx
@@ -6,7 +6,7 @@ export default function FollowProfile({ onPress }: { onPress: () => void }) {
     <XStack w="100%" my="$3" gap="$2">
       <Button
         variant="outlined"
-        borderColor={theme.borderColor?.val.default.val}
+        borderColor={theme.color?.val.default.val}
         size="$4"
         color={theme.color?.val.default.val}
         fontWeight="bold"


### PR DESCRIPTION
# Changes
Makes the Follow Requested button on profiles use the theming so it is properly visible in all themes now.
<details>
<summary>Fixes this bug, click to view screenshot</summary>
<img src="https://github.com/user-attachments/assets/0e811fb7-39b8-45a8-bb13-cfab4356082b">
</details>

# Blockers
None.