### PR TITLE
View comment text plural adapatability

### DIFF
--- a/src/components/post/FeedPost.tsx
+++ b/src/components/post/FeedPost.tsx
@@ -702,7 +702,7 @@ const PostCaption = React.memo(
           {commentsCount ? (
             <Pressable onPress={() => onOpenComments()}>
               <Text color={theme.color?.val.secondary.val} fontSize="$3">
-                View all {commentsCount} comments
+                {commentsCount > 1 ? `View all ${commentsCount} comments` : "View 1 comment"}
               </Text>
             </Pressable>
           ) : null}


### PR DESCRIPTION
# Changes
Makes the text button below a post change if the amount of comments is plural or just 1.
 
# Blockers

If there is actually 0, is it possible that `commentsCount` will equal 0? To be safe, should the second text be `View ${commentsCount} comment` rather than `View 1 comment`?
