### PR TITLE
Private posting scope

### DIFF
--- a/src/app/(auth)/(tabs)/camera.tsx
+++ b/src/app/(auth)/(tabs)/camera.tsx
@@ -774,21 +774,21 @@ export default function Camera() {
                     />
                   </Button>
                 </XStack>
-                  <Button p="$0" chromeless onPress={toggleScope} disabled={userSelf && userSelf?.locked ? true : false}>
-                    <Text
-                      color={theme.color?.val.secondary.val}
-                      fontSize="$3"
-                      allowFontScaling={false}
-                    >
-                      {scopeLabel[scope]}
-                    </Text>
-                    <Feather
-                      name={scopeIcon[scope]}
-                      size={24}
-                      allowFontScaling={false}
-                      color={theme.color?.val.tertiary.val}
-                    />
-                  </Button>
+                <Button p="$0" chromeless onPress={toggleScope} disabled={userSelf && userSelf?.locked ? true : false}>
+                  <Text
+                    color={theme.color?.val.secondary.val}
+                    fontSize="$3"
+                    allowFontScaling={false}
+                  >
+                    {scopeLabel[scope]}
+                  </Text>
+                  <Feather
+                    name={scopeIcon[scope]}
+                    size={24}
+                    allowFontScaling={false}
+                    color={theme.color?.val.tertiary.val}
+                  />
+                </Button>
               </XStack>
             </YStack>
             <View ml="$3" mt="$3">

--- a/src/app/(auth)/(tabs)/camera.tsx
+++ b/src/app/(auth)/(tabs)/camera.tsx
@@ -312,6 +312,24 @@ export default function Camera() {
     }
   }
 
+  const renderScopeLabel = () => (
+    <>
+      <Text
+        color={theme.color?.val.secondary.val}
+        fontSize="$3"
+        allowFontScaling={false}
+      >
+        {scopeLabel[scope]}
+      </Text>
+      <Feather
+        name={scopeIcon[scope]}
+        size={24}
+        allowFontScaling={false}
+        color={theme.color?.val.tertiary.val}
+      />
+    </>
+  )
+
   const saveAltText = () => {
     setMedia(
       media.map((m, idx) => {
@@ -769,21 +787,13 @@ export default function Camera() {
                     />
                   </Button>
                 </XStack>
-                <Button p="$0" chromeless onPress={toggleScope}>
-                  <Text
-                    color={theme.color?.val.secondary.val}
-                    fontSize="$3"
-                    allowFontScaling={false}
-                  >
-                    {scopeLabel[scope]}
-                  </Text>
-                  <Feather
-                    name={scopeIcon[scope]}
-                    size={24}
-                    allowFontScaling={false}
-                    color={theme.color?.val.tertiary.val}
-                  />
-                </Button>
+                { userSelf && userSelf?.locked ? (
+                  renderScopeLabel
+                ) : (
+                  <Button p="$0" chromeless onPress={toggleScope}>
+                    {renderScopeLabel}
+                  </Button> 
+                )}
               </XStack>
             </YStack>
             <View ml="$3" mt="$3">

--- a/src/app/(auth)/(tabs)/camera.tsx
+++ b/src/app/(auth)/(tabs)/camera.tsx
@@ -317,24 +317,6 @@ export default function Camera() {
     }
   }
 
-  const renderScopeLabel = () => (
-    <>
-      <Text
-        color={theme.color?.val.secondary.val}
-        fontSize="$3"
-        allowFontScaling={false}
-      >
-        {scopeLabel[scope]}
-      </Text>
-      <Feather
-        name={scopeIcon[scope]}
-        size={24}
-        allowFontScaling={false}
-        color={theme.color?.val.tertiary.val}
-      />
-    </>
-  )
-
   const saveAltText = () => {
     setMedia(
       media.map((m, idx) => {
@@ -792,13 +774,21 @@ export default function Camera() {
                     />
                   </Button>
                 </XStack>
-                { userSelf && userSelf?.locked ? (
-                  renderScopeLabel
-                ) : (
-                  <Button p="$0" chromeless onPress={toggleScope}>
-                    {renderScopeLabel}
-                  </Button> 
-                )}
+                  <Button p="$0" chromeless onPress={toggleScope} disabled={userSelf && userSelf?.locked ? true : false}>
+                    <Text
+                      color={theme.color?.val.secondary.val}
+                      fontSize="$3"
+                      allowFontScaling={false}
+                    >
+                      {scopeLabel[scope]}
+                    </Text>
+                    <Feather
+                      name={scopeIcon[scope]}
+                      size={24}
+                      allowFontScaling={false}
+                      color={theme.color?.val.tertiary.val}
+                    />
+                  </Button>
               </XStack>
             </YStack>
             <View ml="$3" mt="$3">

--- a/src/app/(auth)/(tabs)/camera.tsx
+++ b/src/app/(auth)/(tabs)/camera.tsx
@@ -289,6 +289,7 @@ export default function Camera() {
   }
 
   const warningMessage = () => {
+    const isPrivateAccount = userSelf && userSelf?.locked
     if (!isSensitive && scope == 'public') {
       return
     }
@@ -299,14 +300,18 @@ export default function Camera() {
       if (scope == 'unlisted') {
         return 'You marked this post as sensitive and unlisted, it will be hidden from public timelines and behind a warning before media is displayed.'
       }
-      if (scope == 'private') {
+      if (isPrivateAccount && scope == 'private') {
+        return 'You marked this post as sensitive and private, it will only be shared to your followers and be hidden behind a warning before media is displayed. Creating public posts is disabled for private accounts.'
+      } else if (scope == 'private') {
         return 'You marked this post as sensitive and private, it will only be shared to your followers and be hidden behind a warning before media is displayed.'
       }
     } else {
       if (scope == 'unlisted') {
         return 'You marked this post as unlisted, it will be hidden from public timelines.'
       }
-      if (scope == 'private') {
+      if (isPrivateAccount && scope == 'private') {
+        return 'This post is marked as private, it will only be shared to your followers. Creating public posts is disabled for private accounts.'
+      } else if (scope == 'private') {
         return 'You marked this post as private, it will only be shared to your followers.'
       }
     }


### PR DESCRIPTION
# Changes
If the users account is Private, the toggle posting scope button (on new posts) will be disabled since other posting scopes are not available for Private Accounts. This reflects the webUI which also does not allow these to be changed.

## Note

This button gets stuck at other levels right after a profile is made private, but once re-rendered (which always happens when media is added), it will correctly switch to followers-only. This is therefore a non-issue, ideally the app is forced to re-render every page since there are other things that also don't instantly change from a setting change.

# Blockers
None.

# Related issues
solves #427
