### PR TITLE
Bugfix: verifyCredentials: Validate 200 HTTP status;

### DIFF
--- a/src/requests.ts
+++ b/src/requests.ts
@@ -193,6 +193,10 @@ export async function verifyCredentials(domain: string, token: string) {
     token
   )
 
+  if (!resp.ok) {
+    throw new Error(`Credential verification failed with status ${resp.status}`)
+  }
+
   return resp.json()
 }
 


### PR DESCRIPTION
Error 401 Unauthorized return JSON objects like {"error": "Invalid token"}. These would be passed down regardless if valid or not.

Now fails on non-2xx responses.