### PR TITLE
Bugfix: useOnlineManager treats null isInternetReachable as offline

### DIFF
--- a/src/hooks/useOnlineManager.ts
+++ b/src/hooks/useOnlineManager.ts
@@ -11,7 +11,7 @@ export function useOnlineManager() {
         onlineManager.setOnline(
           state.isConnected != null &&
             state.isConnected &&
-            Boolean(state.isInternetReachable)
+            state.isInternetReachable !== false
         )
       })
     }


### PR DESCRIPTION
`{ isConnected: true, isInternetReachable: null }` is a valid response.

`On iOS, the first call to NetInfo.fetch() returns isInternetReachable: null, but subsequent calls return the correct boolean value (~100ms later).`
