### PR TITLE
Bugfix: (Android 13+ requires await when creating notification channel prevents notification permission prompt

### DIFF
--- a/src/components/notifications/PushNotificationSettings.tsx
+++ b/src/components/notifications/PushNotificationSettings.tsx
@@ -20,7 +20,7 @@ function handleRegistrationError(errorMessage: string) {
 
 async function registerForPushNotificationsAsync() {
   if (Platform.OS === 'android') {
-    Notifications.setNotificationChannelAsync('default', {
+    await Notifications.setNotificationChannelAsync('default', {
       name: 'default',
       importance: Notifications.AndroidImportance.MAX,
       vibrationPattern: [0, 250, 250, 250],


### PR DESCRIPTION
On Android 13+, the notification permission prompt may not appear

```
Reference example from Expo:

async function registerForPushNotificationsAsync() {
  if (Platform.OS === 'android') {
    await Notifications.setNotificationChannelAsync('myNotificationChannel', {
      name: 'A channel is needed for the permissions prompt to appear',
      importance: Notifications.AndroidImportance.MAX,
      vibrationPattern: [0, 250, 250, 250],
      lightColor: '#FF231F7C',
    });
  }
  // ...
}
```