### PR TITLE
Safety: Chats might respond with null for a conversation.

### DIFF
--- a/src/app/(auth)/chats/index.tsx
+++ b/src/app/(auth)/chats/index.tsx
@@ -122,7 +122,7 @@ export default function Page() {
                   ·
                 </Text>
                 <Text fontSize="$2" allowFontScaling={false} color="#aaa">
-                  {_timeAgo(item.last_status.created_at)} ago
+                  {item.last_status?.created_at ? _timeAgo(item.last_status.created_at) + ' ago' : ''}
                 </Text>
               </XStack>
             </YStack>


### PR DESCRIPTION
`Error occurred: Cannot read properties of null (reading 'created_at')`