### PR TITLE
Safety: Update Network error fallback to use isCredentialsCacheValid()

### DIFF
--- a/src/state/AuthProvider.tsx
+++ b/src/state/AuthProvider.tsx
@@ -81,19 +81,14 @@ function useProtectedRoute(user: User | null, setUser: any, setIsLoading: any) {
               invalidateCredentialsCache()
               setIsLoading(false)
             }
-          } catch (_error) {
-            // Network error or server issues - use cached credentials if available
-            const lastVerified = Storage.getNumber('app.credentials_verified_at')
-            if (lastVerified) {
-              setUser({
-                server: server,
-                token: token,
-              })
-            } else {
-            }
-            setIsLoading(false)
+        } catch (_error) {
+          // Network error or server issues - use cached credentials if available
+          if (isCredentialsCacheValid()) {
+            setUser({
+              server: server,
+              token: token,
+            })
           }
-        } else {
           setIsLoading(false)
         }
       } catch (_error) {


### PR DESCRIPTION
I think this is on purpose to allow people to access the app if the server is down for more than a week?

Close if this is the case.