### PR TITLE
Bugfix: ApiContext.request logs out users on 403 Forbidden AND 401 Unauthorized.

### DIFF
--- a/src/lib/api-context.ts
+++ b/src/lib/api-context.ts
@@ -62,8 +62,8 @@ export class ApiContext {
 
     let response = await fetch(url, fetch_options)
 
-    // Handle unauthorized responses (401 or 403)
-    if (response.status === 401 || response.status === 403) {
+    // Handle unauthorized responses (401 only)
+    if (response.status === 401) {
       this.handleUnauthorized()
       throw new Error('Authentication failed - user has been logged out')
     }


### PR DESCRIPTION
403 Forbidden is not a fail state to trigger a logout.