### PR TITLE
bugfix: remove manually generated multipart/form-data without boundry in api.ts 

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -47,7 +47,9 @@ export async function selfPost<
 
   headers['Authorization'] = `Bearer ${token}`
   headers['Accept'] = 'application/json'
-  headers['Content-Type'] = asForm ? 'multipart/form-data' : 'application/json'
+  if (!asForm) {
+    headers['Content-Type'] = 'application/json'
+  }
 
   if (idempotency) {
     headers['Idempotency-Key'] = randomKey(40)


### PR DESCRIPTION
The header is manually set to multipart/form-data without a boundary, best practice taken from MDN/React Native guidance that fetch should set it automatically.

`Content-Type: multipart/form-data; boundary=...`