### PR TITLE
Bugfix: Allow custom server for registration

### DIFF
--- a/__tests__/registration-servers.test.js
+++ b/__tests__/registration-servers.test.js
@@ -1,0 +1,30 @@
+import { getRegisterServers } from '../src/lib/api'
+
+jest.mock('../src/requests', () => ({}))
+jest.mock('../src/state/cache', () => ({}))
+jest.mock('../src/utils', () => ({}))
+jest.mock('../src/lib/api-context', () => ({}))
+jest.mock('../src/lib/randomKey', () => ({}))
+
+afterEach(() => jest.restoreAllMocks())
+
+test('rejects a failed directory response before attempting to parse it', async () => {
+  const json = jest.fn()
+  jest.spyOn(global, 'fetch').mockResolvedValue({ ok: false, status: 404, json })
+  await expect(getRegisterServers()).rejects.toThrow('404')
+  expect(json).not.toHaveBeenCalled()
+})
+
+test('rejects a directory response that is not a server list', async () => {
+  jest.spyOn(global, 'fetch').mockResolvedValue({
+    ok: true,
+    json: async () => ({ error: 'unavailable' }),
+  })
+  await expect(getRegisterServers()).rejects.toThrow('Invalid registration server list')
+})
+
+test('returns the directory servers', async () => {
+  const servers = [{ domain: 'photos.example.org', user_count: 10 }]
+  jest.spyOn(global, 'fetch').mockResolvedValue({ ok: true, json: async () => servers })
+  await expect(getRegisterServers()).resolves.toEqual(servers)
+})

--- a/__tests__/signup.test.js
+++ b/__tests__/signup.test.js
@@ -1,0 +1,132 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import * as WebBrowser from 'expo-web-browser'
+import { act, create } from 'jest-expo/node_modules/react-test-renderer'
+import SignupScreen from '../src/app/(public)/handleSignup'
+import { getRegisterServers } from '../src/lib/api'
+
+// Expo's renderer must share the app's React instance, not its nested RSC React build.
+jest.mock('jest-expo/node_modules/react', () => jest.requireActual('react'))
+jest.mock('../src/lib/api', () => ({ getRegisterServers: jest.fn() }))
+jest.mock('../src/utils', () => ({ prettyCount: String }))
+const mockPush = jest.fn()
+jest.mock('expo-router', () => ({ useRouter: () => ({ push: mockPush }) }))
+jest.mock('expo-web-browser', () => ({
+  openBrowserAsync: jest.fn().mockResolvedValue({ type: 'dismiss' }),
+  openAuthSessionAsync: jest.fn().mockResolvedValue({ type: 'cancel' }),
+}))
+jest.mock('@expo/vector-icons/Feather', () => 'Icon')
+jest.mock('tamagui', () => ({
+  ...Object.fromEntries(
+    ['Button', 'Image', 'Input', 'ScrollView', 'Text', 'View', 'XStack', 'YStack'].map(
+      (name) => [name, name]
+    )
+  ),
+  useTheme: () => ({}),
+}))
+
+let screen
+let client
+
+async function renderSignup() {
+  client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: Infinity } },
+  })
+  await act(async () => {
+    screen = create(
+      <QueryClientProvider client={client}>
+        <SignupScreen />
+      </QueryClientProvider>
+    )
+  })
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 20))
+  })
+}
+
+function button(label) {
+  return screen.root.findAllByType('Button').find((node) => node.props.children === label)
+}
+
+afterEach(() => {
+  if (screen) act(() => screen.unmount())
+  client?.clear()
+  jest.clearAllMocks()
+})
+
+test('a failed server directory still lets someone register on their own server', async () => {
+  getRegisterServers.mockRejectedValue(new Error('HTTP 404'))
+  await renderSignup()
+
+  const input = screen.root.findByProps({ accessibilityLabel: 'Server domain' })
+  act(() => input.props.onChangeText('photos.example.org'))
+  const signup = button('Sign Up on photos.example.org')
+  expect(signup).toBeDefined()
+  await act(async () => signup.props.onPress())
+  expect(WebBrowser.openBrowserAsync).toHaveBeenCalledWith(
+    'https://photos.example.org/register'
+  )
+  expect(WebBrowser.openAuthSessionAsync).not.toHaveBeenCalled()
+  act(() => {
+    let login = screen.root
+      .findAllByType('Text')
+      .find((node) => node.props.children === 'Log In')
+    while (!login.props.onPress) login = login.parent
+    login.props.onPress()
+  })
+  expect(mockPush).toHaveBeenCalledWith({
+    pathname: '/handleLogin',
+    params: { server: 'photos.example.org' },
+  })
+})
+
+test.each([
+  ['empty', []],
+  ['still loading', new Promise(() => {})],
+])('manual registration is available when the directory is %s', async (_label, data) => {
+  getRegisterServers.mockReturnValue(data)
+  await renderSignup()
+  act(() =>
+    screen.root
+      .findByProps({ accessibilityLabel: 'Server domain' })
+      .props.onChangeText(' HTTPS://Photos.Example.org/ ')
+  )
+  await act(async () => button('Sign Up on photos.example.org').props.onPress())
+  expect(WebBrowser.openBrowserAsync).toHaveBeenCalledWith(
+    'https://photos.example.org/register'
+  )
+})
+
+test.each([
+  '',
+  'not a domain',
+  'photos.example.org/path',
+  'photos.example.org@evil.example',
+])('invalid input %j clears the previously selected server', async (input) => {
+  getRegisterServers.mockResolvedValue([])
+  await renderSignup()
+  const field = screen.root.findByProps({ accessibilityLabel: 'Server domain' })
+  act(() => field.props.onChangeText('photos.example.org'))
+  act(() => field.props.onChangeText(input))
+  expect(screen.root.findAllByType('Button')).toHaveLength(0)
+  expect(WebBrowser.openBrowserAsync).not.toHaveBeenCalled()
+})
+
+test('selecting a listed server after manual entry retains in-app registration', async () => {
+  getRegisterServers.mockResolvedValue([{ domain: 'listed.example.org', user_count: 10 }])
+  await renderSignup()
+  act(() =>
+    screen.root
+      .findByProps({ accessibilityLabel: 'Server domain' })
+      .props.onChangeText('photos.example.org')
+  )
+  act(() => screen.root.findAllByProps({ accessibilityRole: 'radio' })[0].props.onPress())
+  expect(
+    screen.root.findByProps({ accessibilityLabel: 'Server domain' }).props.value
+  ).toBe('')
+  await act(async () => button('Sign Up on listed.example.org').props.onPress())
+  expect(WebBrowser.openAuthSessionAsync).toHaveBeenCalledWith(
+    'https://listed.example.org/i/app-email-verify',
+    'pixelfed://verifyEmail'
+  )
+  expect(WebBrowser.openBrowserAsync).not.toHaveBeenCalled()
+})

--- a/src/app/(public)/handleSignup.tsx
+++ b/src/app/(public)/handleSignup.tsx
@@ -1,5 +1,4 @@
 import Feather from '@expo/vector-icons/Feather'
-import { useAuth } from '@state/AuthProvider'
 import { useQuery } from '@tanstack/react-query'
 import { useRouter } from 'expo-router'
 import * as WebBrowser from 'expo-web-browser'
@@ -15,20 +14,30 @@ import {
 } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { getRegisterServers } from 'src/lib/api'
-import type { OpenServer } from 'src/lib/api-types'
 import { prettyCount } from 'src/utils'
-import { Button, Image, ScrollView, Text, useTheme, View, XStack, YStack } from 'tamagui'
+import {
+  Button,
+  Image,
+  Input,
+  ScrollView,
+  Text,
+  useTheme,
+  View,
+  XStack,
+  YStack,
+} from 'tamagui'
 
 export default function SignupScreen() {
   const [server, setServer] = useState('pixelfed.social')
+  const [customServer, setCustomServer] = useState('')
+  const [isCustomServer, setIsCustomServer] = useState(false)
   const [loading, setLoading] = useState(false)
   const [showInfo, setShowInfo] = useState(false)
   const [_showServerInfo, _setShowServerInfo] = useState(false)
   const [_hasAttemptedSignup, setHasAttemptedSignup] = useState(false)
   const [signupEmail, setSignupEmail] = useState('')
   const infoHeight = useRef(new Animated.Value(0)).current
-  const scrollViewRef = useRef(null)
-  const { login } = useAuth()
+  const scrollViewRef = useRef<RNScrollView>(null)
   const router = useRouter()
   const theme = useTheme()
 
@@ -41,64 +50,39 @@ export default function SignupScreen() {
     }).start()
   }, [showInfo])
 
-  const { data: serversData, isLoading: loadingServers } = useQuery({
+  const {
+    data: serversData,
+    isLoading: loadingServers,
+    isError: serverListError,
+  } = useQuery({
     queryKey: ['getRegisterServers'],
-    queryFn: async () => {
-      try {
-        const res = await getRegisterServers()
-        return res
-      } catch (_error) {
-        return [
-          {
-            domain: 'pixelfed.social',
-            header_thumbnail: 'https://pixelfed.org/storage/servers/header.png',
-            version: '0.12.4',
-            short_description:
-              'The original Pixelfed instance, operated by the main developer @dansup',
-            rules: [],
-            user_count: 420069,
-            last_seen_at: getNowTimestamp(),
-          },
-        ]
-      }
-    },
+    queryFn: getRegisterServers,
+    retry: false,
   })
 
-  const getNowTimestamp = () => {
-    const now = new Date()
-    const year = now.getUTCFullYear()
-    const month = String(now.getUTCMonth() + 1).padStart(2, '0')
-    const day = String(now.getUTCDate()).padStart(2, '0')
-    const hours = String(now.getUTCHours()).padStart(2, '0')
-    const minutes = String(now.getUTCMinutes()).padStart(2, '0')
-    const seconds = String(now.getUTCSeconds()).padStart(2, '0')
-    const milliseconds = String(now.getUTCMilliseconds()).padStart(3, '0') + '000'
-
-    return `${year}-${month}-${day}T${hours}:${minutes}:${seconds}.${milliseconds}Z`
-  }
-
   const filteredServers = React.useMemo(() => {
-    if (!serversData)
-      return [
-        {
-          domain: 'pixelfed.social',
-          header_thumbnail: 'https://pixelfed.org/storage/servers/header.png',
-          version: '0.12.4',
-          short_description:
-            'The original Pixelfed instance, operated by the main developer @dansup',
-          rules: [],
-          user_count: 420069,
-          last_seen_at: getNowTimestamp(),
-        },
-      ]
+    if (!serversData) return [{ domain: 'pixelfed.social', user_count: undefined }]
 
     return [...serversData]
       .filter((s) => Object.hasOwn(s, 'user_count'))
-      .sort((a, b) => (b as OpenServer).user_count - (a as OpenServer).user_count)
-      .slice(0, 10)
+      .sort((a, b) => b.user_count - a.user_count)
   }, [serversData])
 
-  const handleServerSelect = (serverDomain) => {
+  const handleCustomServerChange = (text: string) => {
+    setCustomServer(text)
+    setIsCustomServer(true)
+    const domain = text
+      .trim()
+      .toLowerCase()
+      .replace(/^https?:\/\//, '')
+      .replace(/\/$/, '')
+    const valid = /^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,}$/.test(domain)
+    setServer(valid ? domain : '')
+  }
+
+  const handleServerSelect = (serverDomain: string) => {
+    setIsCustomServer(false)
+    setCustomServer('')
     setServer(serverDomain)
     setTimeout(() => {
       scrollViewRef.current?.scrollToEnd({ animated: true })
@@ -113,6 +97,11 @@ export default function SignupScreen() {
 
     setLoading(true)
     try {
+      if (isCustomServer) {
+        await WebBrowser.openBrowserAsync(`https://${server}/register`)
+        return
+      }
+
       setHasAttemptedSignup(true)
 
       const result = await WebBrowser.openAuthSessionAsync(
@@ -189,7 +178,7 @@ export default function SignupScreen() {
   }
 
   const navigateToLogin = () => {
-    router.push('/handleLogin')
+    router.push({ pathname: '/handleLogin', params: { server } })
   }
 
   const navigateBack = () => {
@@ -198,22 +187,6 @@ export default function SignupScreen() {
 
   const toggleInfo = () => {
     setShowInfo(!showInfo)
-  }
-
-  if (loadingServers) {
-    return (
-      <SafeAreaView
-        style={{
-          backgroundColor: theme.background?.val.default.val,
-          flexGrow: 1,
-          justifyContent: 'center',
-          alignItems: 'center',
-        }}
-        edges={['top']}
-      >
-        <ActivityIndicator color="white" size="large" />
-      </SafeAreaView>
-    )
   }
 
   return (
@@ -330,17 +303,22 @@ export default function SignupScreen() {
                 p="$3"
               >
                 <YStack space="$3" maxHeight={200}>
-                  <ScrollView>
+                  <ScrollView nestedScrollEnabled keyboardShouldPersistTaps="handled">
                     {filteredServers.length > 0 ? (
                       filteredServers.map((item) => (
                         <Pressable
                           key={item.domain}
+                          disabled={loading}
+                          accessibilityRole="radio"
+                          accessibilityState={{
+                            checked: !isCustomServer && server === item.domain,
+                          }}
                           onPress={() => handleServerSelect(item.domain)}
                           style={({ pressed }) => [
                             {
                               opacity: pressed ? 0.7 : 1,
                               backgroundColor:
-                                server === item.domain
+                                !isCustomServer && server === item.domain
                                   ? theme.background?.val.tertiary.val
                                   : 'transparent',
                               borderRadius: 8,
@@ -352,18 +330,24 @@ export default function SignupScreen() {
                           <XStack justifyContent="space-between" alignItems="center">
                             <Text
                               color={
-                                server === item.domain
+                                !isCustomServer && server === item.domain
                                   ? theme.color?.val.default.val
                                   : theme.color?.val.tertiary.val
                               }
                               fontSize="$5"
-                              fontWeight={server === item.domain ? 'bold' : 'normal'}
+                              fontWeight={
+                                !isCustomServer && server === item.domain
+                                  ? 'bold'
+                                  : 'normal'
+                              }
                             >
                               {item.domain}
                             </Text>
-                            <Text fontSize="$3" color={theme.color?.val.tertiary.val}>
-                              {prettyCount(item.user_count)} users
-                            </Text>
+                            {item.user_count !== undefined && (
+                              <Text fontSize="$3" color={theme.color?.val.tertiary.val}>
+                                {prettyCount(item.user_count)} users
+                              </Text>
+                            )}
                           </XStack>
                         </Pressable>
                       ))
@@ -379,6 +363,38 @@ export default function SignupScreen() {
                   </ScrollView>
                 </YStack>
               </View>
+              {loadingServers && <ActivityIndicator />}
+              {serverListError && (
+                <Text color={theme.color?.val.secondary.val}>
+                  Couldn't load the server list. You can enter your server below.
+                </Text>
+              )}
+              <Text color={theme.color?.val.default.val}>Or enter another server</Text>
+              <Input
+                accessibilityLabel="Server domain"
+                color={theme.color?.val.default.val}
+                backgroundColor={theme.background?.val.default.val}
+                borderColor={theme.borderColor?.val.default.val}
+                placeholderTextColor={theme.color?.val.secondary.val}
+                placeholder="photos.example.org"
+                value={customServer}
+                onChangeText={handleCustomServerChange}
+                autoCapitalize="none"
+                autoCorrect={false}
+                keyboardType="url"
+                editable={!loading}
+              />
+              {isCustomServer && !server && customServer.length > 0 && (
+                <Text color={theme.color?.val.secondary.val}>
+                  Enter a valid server domain, such as photos.example.org.
+                </Text>
+              )}
+              {isCustomServer && (
+                <Text color={theme.color?.val.secondary.val}>
+                  Complete registration on your server's website, then return here and tap
+                  Log In. Each server decides whether registration is open.
+                </Text>
+              )}
             </YStack>
 
             {server && (
@@ -401,31 +417,33 @@ export default function SignupScreen() {
 
             {/* Verification Options */}
 
-            <YStack space="$2" mt="$2" gap="$3">
-              <XStack justifyContent="center" space="$2">
-                <Pressable onPress={handleResendVerification}>
-                  <Text
-                    color={theme.colorHover?.val.active.val}
-                    fontWeight="bold"
-                    fontSize="$6"
-                  >
-                    Resend email verification
-                  </Text>
-                </Pressable>
-              </XStack>
+            {!isCustomServer && (
+              <YStack space="$2" mt="$2" gap="$3">
+                <XStack justifyContent="center" space="$2">
+                  <Pressable onPress={handleResendVerification}>
+                    <Text
+                      color={theme.colorHover?.val.active.val}
+                      fontWeight="bold"
+                      fontSize="$6"
+                    >
+                      Resend email verification
+                    </Text>
+                  </Pressable>
+                </XStack>
 
-              <XStack justifyContent="center" space="$2">
-                <Pressable onPress={navigateToVerificationCode}>
-                  <Text
-                    color={theme.colorHover?.val.active.val}
-                    fontWeight="bold"
-                    fontSize="$6"
-                  >
-                    I have a verification code
-                  </Text>
-                </Pressable>
-              </XStack>
-            </YStack>
+                <XStack justifyContent="center" space="$2">
+                  <Pressable onPress={navigateToVerificationCode}>
+                    <Text
+                      color={theme.colorHover?.val.active.val}
+                      fontWeight="bold"
+                      fontSize="$6"
+                    >
+                      I have a verification code
+                    </Text>
+                  </Pressable>
+                </XStack>
+              </YStack>
+            )}
 
             <View flexGrow={1} />
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -461,7 +461,14 @@ export async function getRegisterServers() {
       }),
     }
   )
-  return (await response.json()) as OpenServersResponse
+  if (!response.ok) {
+    throw new Error(`Unable to load registration servers (${response.status})`)
+  }
+  const servers = await response.json()
+  if (!Array.isArray(servers)) {
+    throw new Error('Invalid registration server list')
+  }
+  return servers as OpenServersResponse
 }
 
 export async function getStatusLikes(id: string, cursor) {


### PR DESCRIPTION
When registering, if the server dropdown is unpopulated due to request error, allow the user to enter a custom domain manually. Else they're restricted to registering only for the default pixelfed.social instance.

<img width="1080" height="2340" alt="pixelfeld" src="https://github.com/user-attachments/assets/aae2d939-04c5-4d7d-9b45-8f65fb80a9f2" />


# Changes
* Added a custom server URL input field on registration page


# Blockers

It's my first PR so I may have done some of your process incorrectly. 

# Related issues
* https://github.com/pixelfed/pixelfed-rn/issues/468

